### PR TITLE
move LibV4 internal implementations into file

### DIFF
--- a/efel/cppcore/LibV4.cpp
+++ b/efel/cppcore/LibV4.cpp
@@ -27,7 +27,7 @@
 // get all local minima
 // assume spikes between local minima
 // check if the assumed spike is bigger than min_spike_height
-int LibV4::__peak_indices(const vector<double>& v, double min_spike_height,
+static int __peak_indices(const vector<double>& v, double min_spike_height,
                           double threshold, vector<int>& peakindices) {
   vector<double> dv;
   vector<int> minimum_indices;

--- a/efel/cppcore/LibV4.h
+++ b/efel/cppcore/LibV4.h
@@ -29,7 +29,5 @@ using std::vector;
 namespace LibV4 {
 int peak_indices(mapStr2intVec& IntFeatureData,
                  mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData);
-int __peak_indices(const vector<double>& v, double min_spike_height,
-                   double threshold, vector<int>& peakindices);
 }
 #endif


### PR DESCRIPTION
* Following functions were made non-public
 - __peak_indices
* (checked for references in OptimizerFramework)