### PR TITLE
for python 2.6 to use numpy==1.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
+PYVERSION:=$(shell python -c 'import sys; v = sys.version_info; print("%s.%s" % v[0:2])')
 all: install
 install: clean
+	#on python 2.6, pre-install last supported version of numpy
+	test "2.6" = $(PYVERSION) && pip install 'numpy==1.10.0' || true
 	python setup.py sdist
-	pip install dist/*.tar.gz --upgrade
+	#upgrade all packages to their maximum, except on python 2.6, which needs
+	# to keep numpy at version set above
+	pip install dist/*.tar.gz --upgrade \
+		`test "2.6" = $(PYVERSION) && echo '--upgrade-strategy=only-if-needed'`
 install3: clean
 	python3 setup.py sdist
 	pip3 install dist/*.tar.gz --upgrade


### PR DESCRIPTION
* this is one of the last numpy's to support python 2.6 and have a wheel