### PR TITLE
Don't fail when stimEnd larger than max time in trace

### DIFF
--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -1535,12 +1535,8 @@ static int __maxmin_voltage(const vector<double>& v, const vector<double>& t,
     return -1;
   }
 
-  if (stimEnd > t[t.size() - 1]) {
-    GErrorStr += "\nStimulus end larger than max time in trace. [stim_end: " + 
-        to_string(stimEnd) + ", max time: " + 
-        to_string(t[t.size() - 1]) + "]\n";
-    return -1;
-  }
+  if (stimEnd > t[t.size() - 1])
+      stimEnd = t.back();
 
   size_t stimstartindex = 0;
   while(t[stimstartindex] < stimStart && stimstartindex <= t.size())


### PR DESCRIPTION
just set stimEnd to max time in trace.

The problem I have right now is the following:

```python
    traces = [{
        'T': time,
        'V': voltage,
        'stim_start': [t_stim],
        'stim_end': [np.max(time)],
    }]
    traces_results = efel.getFeatureValues(traces, ['maximum_voltage', 'voltage_base'])
```
However, probably because of a rounding error, `np.max(time)` in python is greater than the C++ equivalent `time[time.size() - 1]`. This triggers the following error:
`Stimulus end larger than max time in trace. [stim_end: 10, max time: 9.9999999999999822]`