### PR TITLE
use set to check if feature names match

### DIFF
--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -1574,7 +1574,7 @@ def test_getFeatureNames():
     test_data_path = os.path.join(testdata_dir, '..', 'featurenames.json')
     with open(test_data_path, 'r') as featurenames_json:
         expected_featurenames = json.load(featurenames_json)
-    nt.assert_equal(efel.getFeatureNames(), expected_featurenames)
+    nt.assert_equal(set(efel.getFeatureNames()), set(expected_featurenames))
 
 
 def test_getFeatureNameExists():


### PR DESCRIPTION
The CPP features and Python features are just appended to each other in the function below.
https://github.com/BlueBrain/eFEL/blob/6a395118e6b3306001878ce08f6aef791ec37f1c/efel/api.py#L177

Their order is not guaranteed to be the same. 
This is one of the reasons why PR https://github.com/BlueBrain/eFEL/pull/165 is failing.

This PR simply puts them into sets and checks if the sets are equal.