### PR TITLE
C++ Templates for allowing mapoperations methods to work on generic types

### DIFF
--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -49,7 +49,7 @@ int LibV1::interpolate(mapStr2intVec& IntFeatureData,
                        mapStr2doubleVec& DoubleFeatureData,
                        mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "interpolate", nSize);
+  retVal = CheckInMap(IntFeatureData, StringData, "interpolate", nSize);
   if (retVal)
     return nSize;
 
@@ -121,7 +121,7 @@ int LibV1::peak_indices(mapStr2intVec& IntFeatureData,
   // printf("\n  LibV1  This is inside peak_indices()");
   int retVal, nSize;
   retVal =
-      CheckInIntmap(IntFeatureData, StringData, "peak_indices", nSize);
+      CheckInMap(IntFeatureData, StringData, "peak_indices", nSize);
   if (retVal)
     return nSize;
   vector<int> PeakIndex;
@@ -144,7 +144,7 @@ int LibV1::Spikecount(mapStr2intVec& IntFeatureData,
   int nsize;
   size_t spikecount_value;
   retval =
-      CheckInIntmap(IntFeatureData, StringData, "Spikecount", nsize);
+      CheckInMap(IntFeatureData, StringData, "Spikecount", nsize);
   if (retval) {
     return nsize;
   }
@@ -171,7 +171,7 @@ int LibV1::ISI_values(mapStr2intVec& IntFeatureData,
                       mapStr2Str& StringData) {
   //  printf("\n  LibV1  This is inside ISI_values()");
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "ISI_values",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "ISI_values",
                             nSize);
   if (retVal)
     return nSize;
@@ -213,7 +213,7 @@ int LibV1::ISI_CV(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "ISI_CV", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "ISI_CV", nsize);
   if (retval) return nsize;
 
   vector<double> isivalues;
@@ -235,7 +235,7 @@ int LibV1::peak_voltage(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   // printf("\n  LibV1  Inside PeakVoltage ... LibV1");
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "peak_voltage", nSize);
   if (retVal)
     return nSize;
@@ -263,7 +263,7 @@ int LibV1::firing_rate(mapStr2intVec& IntFeatureData,
                        mapStr2Str& StringData) {
   // printf("\n  LibV1  This is inside firing_rate()");
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "mean_frequency", nSize);
   if (retVal)
     return nSize;
@@ -298,7 +298,7 @@ int LibV1::peak_time(mapStr2intVec& IntFeatureData,
                      mapStr2Str& StringData) {
   // printf("\n  LibV1  This is inside peak_time()");
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "peak_time", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "peak_time", nSize);
   if (retVal)
     return nSize;
 
@@ -320,7 +320,7 @@ int LibV1::first_spike_time(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "time_to_first_spike", nSize);
   if (retVal)
     return nSize;
@@ -348,7 +348,7 @@ int LibV1::min_AHP_indices(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "min_AHP_indices", nSize);
+  retVal = CheckInMap(IntFeatureData, StringData, "min_AHP_indices", nSize);
   if (retVal)
     return nSize;
 
@@ -396,7 +396,7 @@ int LibV1::min_AHP_values(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "min_AHP_values", nSize);
   if (retVal) return nSize;
   return -1;
@@ -406,7 +406,7 @@ int LibV1::AP_height(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP_height", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP_height", nSize);
   if (retVal)
     return nSize;
 
@@ -424,7 +424,7 @@ int LibV1::AP_amplitude(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "AP_amplitude", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "AP_amplitude", nSize);
   if (retVal > 0)
     return nSize;
 
@@ -510,7 +510,7 @@ int LibV1::AHP_depth_abs(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "AHP_depth_abs", nSize);
   if (retVal)
     return nSize;
@@ -552,7 +552,7 @@ int LibV1::AHP_depth_abs_slow(mapStr2intVec& IntFeatureData,
                               mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AHP_depth_abs_slow", nsize);
   if (retval) {
     return nsize;
@@ -595,7 +595,7 @@ int LibV1::AHP_slow_time(mapStr2intVec& IntFeatureData,
                          mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "AHP_slow_time", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "AHP_slow_time", nSize);
   if (retVal) return nSize;
   return -1;
 }
@@ -604,7 +604,7 @@ int LibV1::rest_voltage_value(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "voltage_base", nSize);
   if (retVal)
     return nSize;
@@ -669,7 +669,7 @@ int LibV1::burst_ISI_indices(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "burst_ISI_indices", nSize);
   if (retVal)
     return nSize;
@@ -727,7 +727,7 @@ int LibV1::burst_mean_freq(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "burst_mean_freq", nSize);
   if (retVal)
     return nSize;
@@ -753,7 +753,7 @@ int LibV1::burst_number(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInIntmap(IntFeatureData, StringData, "burst_number", nSize);
+      CheckInMap(IntFeatureData, StringData, "burst_number", nSize);
   if (retVal)
     return nSize;
 
@@ -803,7 +803,7 @@ int LibV1::interburst_voltage(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "interburst_voltage", nSize);
   if (retVal)
     return nSize;
@@ -885,7 +885,7 @@ int LibV1::adaptation_index(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "adaptation_index", nSize);
   if (retVal)
     return nSize;
@@ -976,7 +976,7 @@ int LibV1::adaptation_index2(mapStr2intVec& IntFeatureData,
                              mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "adaptation_index2", nsize);
   if (retval) return nsize;
 
@@ -1020,7 +1020,7 @@ int LibV1::trace_check(mapStr2intVec& IntFeatureData,
                        mapStr2Str& StringData) {
   int retval;
   int size;
-  retval = CheckInIntmap(IntFeatureData, StringData, "trace_check", size);
+  retval = CheckInMap(IntFeatureData, StringData, "trace_check", size);
   if (retval)
     return size;
 
@@ -1141,7 +1141,7 @@ int LibV1::spike_width2(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "spike_width2", nSize);
   if (retVal)
     return nSize;
@@ -1217,7 +1217,7 @@ int LibV1::spike_width1(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "spike_half_width", nSize);
   if (retVal)
     return nSize;
@@ -1400,7 +1400,7 @@ int LibV1::time_constant(mapStr2intVec& IntFeatureData,
                          mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "time_constant", nSize);
   if (retVal)
     return nSize;
@@ -1466,7 +1466,7 @@ int LibV1::voltage_deflection(mapStr2intVec& IntFeatureData,
                               mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "voltage_deflection", nSize);
   if (retVal)
     return nSize;
@@ -1505,7 +1505,7 @@ int LibV1::ohmic_input_resistance(mapStr2intVec& IntFeatureData,
                                   mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "ohmic_input_resistance", nSize);
   if (retVal)
     return nSize;
@@ -1568,7 +1568,7 @@ int LibV1::maximum_voltage(mapStr2intVec& IntFeatureData,
                            mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "maximum_voltage", nSize);
   if (retVal)
     return nSize;
@@ -1601,7 +1601,7 @@ int LibV1::minimum_voltage(mapStr2intVec& IntFeatureData,
                            mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "minimum_voltage", nSize);
   if (retVal)
     return nSize;
@@ -1646,7 +1646,7 @@ int LibV1::steady_state_voltage(mapStr2intVec& IntFeatureData,
                                 mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "steady_state_voltage", nSize);
   if (retVal)
     return nSize;
@@ -1692,7 +1692,7 @@ int LibV1::single_burst_ratio(mapStr2intVec& IntFeatureData,
                               mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "single_burst_ratio", nsize);
   if (retval) {
     return nsize;
@@ -1718,7 +1718,7 @@ int LibV1::threshold_current(mapStr2intVec& IntFeatureData,
                              mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "threshold_current", nsize);
   if (retval) {
     return nsize;
@@ -1816,7 +1816,7 @@ int LibV1::AP_width(mapStr2intVec& IntFeatureData,
                     mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "AP_width",
+  retval = CheckInMap(DoubleFeatureData, StringData, "AP_width",
                             nsize);
   if (retval) {
     return nsize;
@@ -1861,7 +1861,7 @@ int LibV1::doublet_ISI(mapStr2intVec& IntFeatureData,
                        mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "doublet_ISI", nsize);
   if (retval) {
     return nsize;
@@ -1894,7 +1894,7 @@ int LibV1::AHP_depth(mapStr2intVec& IntFeatureData,
                      mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "AHP_depth", nsize);
+  retval = CheckInMap(DoubleFeatureData, StringData, "AHP_depth", nsize);
   if (retval) {
     return nsize;
   }
@@ -1933,7 +1933,7 @@ int LibV1::AP_amplitude_diff(mapStr2intVec& IntFeatureData,
                              mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_amplitude_diff", nsize);
   if (retval) {
     return nsize;
@@ -1969,7 +1969,7 @@ int LibV1::AHP_depth_diff(mapStr2intVec& IntFeatureData,
                           mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AHP_depth_diff", nsize);
   if (retval) {
     return nsize;

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -70,9 +70,9 @@ int LibV1::interpolate(mapStr2intVec& IntFeatureData,
 
   LinearInterpolation(InterpStep, T, V, TIntrpol, VIntrpol);
 
-  setDoubleVec(DoubleFeatureData, StringData, "V", VIntrpol);
-  setDoubleVec(DoubleFeatureData, StringData, "T", TIntrpol);
-  setIntVec(IntFeatureData, StringData, "interpolate", intrpolte);
+  setVec(DoubleFeatureData, StringData, "V", VIntrpol);
+  setVec(DoubleFeatureData, StringData, "T", TIntrpol);
+  setVec(IntFeatureData, StringData, "interpolate", intrpolte);
   return retVal;
 }
 
@@ -132,7 +132,7 @@ int LibV1::peak_indices(mapStr2intVec& IntFeatureData,
   if (retVal <= 0) return -1;
   int retval = __peak_indices(Th[0], v, PeakIndex);
   if (retval >= 0)
-    setIntVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
+    setVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
   return retval;
 }
 
@@ -160,7 +160,7 @@ int LibV1::Spikecount(mapStr2intVec& IntFeatureData,
   }
   vector<int> spikecount(1, spikecount_value);
   if (retval >= 0) {
-    setIntVec(IntFeatureData, StringData, "Spikecount", spikecount);
+    setVec(IntFeatureData, StringData, "Spikecount", spikecount);
   }
   return retval;
 }
@@ -184,7 +184,7 @@ int LibV1::ISI_values(mapStr2intVec& IntFeatureData,
   }
   for (size_t i = 2; i < pvTime.size(); i++)
     VecISI.push_back(pvTime[i] - pvTime[i - 1]);
-  setDoubleVec(DoubleFeatureData, StringData, "ISI_values", VecISI);
+  setVec(DoubleFeatureData, StringData, "ISI_values", VecISI);
   return VecISI.size();
 }
 
@@ -224,7 +224,7 @@ int LibV1::ISI_CV(mapStr2intVec& IntFeatureData,
   vector<double> isicv;
   retval = __ISI_CV(isivalues, isicv);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "ISI_CV", isicv);
+    setVec(DoubleFeatureData, StringData, "ISI_CV", isicv);
   }
   return retval;
 }
@@ -254,7 +254,7 @@ int LibV1::peak_voltage(mapStr2intVec& IntFeatureData,
   for (size_t i = 0; i < PeakI.size(); i++) {
     peakV.push_back(V[PeakI[i]]);
   }
-  setDoubleVec(DoubleFeatureData, StringData, "peak_voltage", peakV);
+  setVec(DoubleFeatureData, StringData, "peak_voltage", peakV);
   return peakV.size();
 }
 
@@ -289,7 +289,7 @@ int LibV1::firing_rate(mapStr2intVec& IntFeatureData,
     return -1;
   }
   firing_rate.push_back(nCount * 1000 / (lastAPTime - stimStart[0]));
-  setDoubleVec(DoubleFeatureData, StringData, "mean_frequency", firing_rate);
+  setVec(DoubleFeatureData, StringData, "mean_frequency", firing_rate);
   return firing_rate.size();
 }
 
@@ -311,7 +311,7 @@ int LibV1::peak_time(mapStr2intVec& IntFeatureData,
   for (size_t i = 0; i < PeakI.size(); i++) {
     pvTime.push_back(T[PeakI[i]]);
   }
-  setDoubleVec(DoubleFeatureData, StringData, "peak_time", pvTime);
+  setVec(DoubleFeatureData, StringData, "peak_time", pvTime);
   return pvTime.size();
 }
 
@@ -336,7 +336,7 @@ int LibV1::first_spike_time(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retVal <= 0) return -1;
   first_spike.push_back(peaktime[0] - stimstart[0]);
-  setDoubleVec(DoubleFeatureData, StringData, "time_to_first_spike",
+  setVec(DoubleFeatureData, StringData, "time_to_first_spike",
                first_spike);
   return first_spike.size();
 }
@@ -387,8 +387,8 @@ int LibV1::min_AHP_indices(mapStr2intVec& IntFeatureData,
     min_ahp_indices.push_back(ahpindex);
     min_ahp_values.push_back(v[ahpindex]);
   }
-  setIntVec(IntFeatureData, StringData, "min_AHP_indices", min_ahp_indices);
-  setDoubleVec(DoubleFeatureData, StringData, "min_AHP_values", min_ahp_values);
+  setVec(IntFeatureData, StringData, "min_AHP_indices", min_ahp_indices);
+  setVec(DoubleFeatureData, StringData, "min_AHP_values", min_ahp_values);
   return min_ahp_indices.size();
 }
 
@@ -413,7 +413,7 @@ int LibV1::AP_height(mapStr2intVec& IntFeatureData,
   vector<double> vPeak;
   retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_voltage", vPeak);
   if (retVal <= 0) return -1;
-  setDoubleVec(DoubleFeatureData, StringData, "AP_height", vPeak);
+  setVec(DoubleFeatureData, StringData, "AP_height", vPeak);
 
   return vPeak.size();
 }
@@ -496,7 +496,7 @@ int LibV1::AP_amplitude(mapStr2intVec& IntFeatureData,
   for (size_t i = 0; i < apamplitude.size(); i++) {
     apamplitude[i] = peakvoltage_duringstim[i] - v[apbeginindices[i]];
   }
-  setDoubleVec(DoubleFeatureData, StringData, "AP_amplitude", apamplitude);
+  setVec(DoubleFeatureData, StringData, "AP_amplitude", apamplitude);
   return apamplitude.size();
 }
 
@@ -519,7 +519,7 @@ int LibV1::AHP_depth_abs(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData,
                         "min_AHP_values", vAHP);
   if (retVal <= 0) return -1;
-  setDoubleVec(DoubleFeatureData, StringData, "AHP_depth_abs", vAHP);
+  setVec(DoubleFeatureData, StringData, "AHP_depth_abs", vAHP);
   return vAHP.size();
 }
 
@@ -582,9 +582,9 @@ int LibV1::AHP_depth_abs_slow(mapStr2intVec& IntFeatureData,
                      (t[peakindices[i + 2]] - t[peakindices[i + 1]]);
   }
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AHP_depth_abs_slow",
+    setVec(DoubleFeatureData, StringData, "AHP_depth_abs_slow",
                  ahpdepthabsslow);
-    setDoubleVec(DoubleFeatureData, StringData, "AHP_slow_time", ahpslowtime);
+    setVec(DoubleFeatureData, StringData, "AHP_slow_time", ahpslowtime);
   }
   return retval;
 }
@@ -633,7 +633,7 @@ int LibV1::rest_voltage_value(mapStr2intVec& IntFeatureData,
     if (t[i] > endTime) break;
   }
   vRest.push_back(vSum / nCount);
-  setDoubleVec(DoubleFeatureData, StringData, "voltage_base", vRest);
+  setVec(DoubleFeatureData, StringData, "voltage_base", vRest);
   return 1;
 }
 
@@ -693,7 +693,7 @@ int LibV1::burst_ISI_indices(mapStr2intVec& IntFeatureData,
 
   retVal = __burst_ISI_indices(BurstFactor, PeakIndex, ISIValues, BurstIndex);
   if (retVal >= 0) {
-    setIntVec(IntFeatureData, StringData, "burst_ISI_indices", BurstIndex);
+    setVec(IntFeatureData, StringData, "burst_ISI_indices", BurstIndex);
   }
   return retVal;
 }
@@ -742,7 +742,7 @@ int LibV1::burst_mean_freq(mapStr2intVec& IntFeatureData,
 
   retVal = __burst_mean_freq(PVTime, BurstIndex, BurstMeanFreq);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "burst_mean_freq",
+    setVec(DoubleFeatureData, StringData, "burst_mean_freq",
                  BurstMeanFreq);
   }
   return retVal;
@@ -764,7 +764,7 @@ int LibV1::burst_number(mapStr2intVec& IntFeatureData,
   if (retVal < 0) return -1;
 
   BurstNum.push_back(BurstMeanFreq.size());
-  setIntVec(IntFeatureData, StringData, "burst_number", BurstNum);
+  setVec(IntFeatureData, StringData, "burst_number", BurstNum);
   return (BurstNum.size());
 }
 
@@ -822,7 +822,7 @@ int LibV1::interburst_voltage(mapStr2intVec& IntFeatureData,
 
   retVal = __interburst_voltage(BurstIndex, PeakIndex, T, V, IBV);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "interburst_voltage", IBV);
+    setVec(DoubleFeatureData, StringData, "interburst_voltage", IBV);
   }
   return retVal;
 }
@@ -918,7 +918,7 @@ int LibV1::adaptation_index(mapStr2intVec& IntFeatureData,
   retVal = __adaptation_index(spikeSkipf[0], maxnSpike[0], stimStart[0],
                               stimEnd[0], Offset, peakVTime, adaptation_index);
   if (retVal >= 0)
-    setDoubleVec(DoubleFeatureData, StringData, "adaptation_index",
+    setVec(DoubleFeatureData, StringData, "adaptation_index",
                  adaptation_index);
   return retVal;
 }
@@ -1008,7 +1008,7 @@ int LibV1::adaptation_index2(mapStr2intVec& IntFeatureData,
   retval = __adaptation_index2(stimStart[0], stimEnd[0], Offset,
                                peakvoltagetime, adaptationindex2);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "adaptation_index2",
+    setVec(DoubleFeatureData, StringData, "adaptation_index2",
                  adaptationindex2);
   }
   return retval;
@@ -1044,7 +1044,7 @@ int LibV1::trace_check(mapStr2intVec& IntFeatureData,
   }
   if (sane) {
     tc.push_back(0);
-    setIntVec(IntFeatureData, StringData, "trace_check", tc);
+    setVec(IntFeatureData, StringData, "trace_check", tc);
     return tc.size();
   } else {
     GErrorStr +=
@@ -1165,7 +1165,7 @@ int LibV1::spike_width2(mapStr2intVec& IntFeatureData,
   // Using Central difference derivative vec1[i] = ((vec[i+1]+vec[i-1])/2)/dx
   retVal = __spike_width2(t, V, PeakIndex, minAHPIndex, spike_width2);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "spike_width2", spike_width2);
+    setVec(DoubleFeatureData, StringData, "spike_width2", spike_width2);
   }
   return retVal;
 }
@@ -1246,7 +1246,7 @@ int LibV1::spike_width1(mapStr2intVec& IntFeatureData,
   retVal = __spike_width1(t, V, PeakIndex, minAHPIndex, stim_start[0],
                           spike_width1);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "spike_half_width",
+    setVec(DoubleFeatureData, StringData, "spike_half_width",
                  spike_width1);
   }
   return retVal;
@@ -1420,7 +1420,7 @@ int LibV1::time_constant(mapStr2intVec& IntFeatureData,
   vector<double> tc;
   retVal = __time_constant(v, t, stimStart[0], stimEnd[0], tc);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "time_constant", tc);
+    setVec(DoubleFeatureData, StringData, "time_constant", tc);
   }
   return retVal;
 }
@@ -1486,7 +1486,7 @@ int LibV1::voltage_deflection(mapStr2intVec& IntFeatureData,
   vector<double> vd;
   retVal = __voltage_deflection(v, t, stimStart[0], stimEnd[0], vd);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "voltage_deflection", vd);
+    setVec(DoubleFeatureData, StringData, "voltage_deflection", vd);
   }
   return retVal;
 }
@@ -1522,7 +1522,7 @@ int LibV1::ohmic_input_resistance(mapStr2intVec& IntFeatureData,
   retVal = __ohmic_input_resistance(voltage_deflection[0],
                                     stimulus_current[0], oir);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "ohmic_input_resistance", oir);
+    setVec(DoubleFeatureData, StringData, "ohmic_input_resistance", oir);
   }
   return retVal;
 }
@@ -1589,7 +1589,7 @@ int LibV1::maximum_voltage(mapStr2intVec& IntFeatureData,
   vector<double> maxV, minV;
   retVal = __maxmin_voltage(v, t, stimStart[0], stimEnd[0], maxV, minV);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "maximum_voltage", maxV);
+    setVec(DoubleFeatureData, StringData, "maximum_voltage", maxV);
   }
   return retVal;
 }
@@ -1621,7 +1621,7 @@ int LibV1::minimum_voltage(mapStr2intVec& IntFeatureData,
   vector<double> maxV, minV;
   retVal = __maxmin_voltage(v, t, stimStart[0], stimEnd[0], maxV, minV);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "minimum_voltage", minV);
+    setVec(DoubleFeatureData, StringData, "minimum_voltage", minV);
   }
   return retVal;
 }
@@ -1664,7 +1664,7 @@ int LibV1::steady_state_voltage(mapStr2intVec& IntFeatureData,
   vector<double> ssv;
   retVal = __steady_state_voltage(v, t, stimEnd[0], ssv);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "steady_state_voltage", ssv);
+    setVec(DoubleFeatureData, StringData, "steady_state_voltage", ssv);
   }
   return retVal;
 }
@@ -1705,7 +1705,7 @@ int LibV1::single_burst_ratio(mapStr2intVec& IntFeatureData,
 
   retval = __single_burst_ratio(isivalues, singleburstratio);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "single_burst_ratio",
+    setVec(DoubleFeatureData, StringData, "single_burst_ratio",
                  singleburstratio);
   }
   return retval;
@@ -1848,7 +1848,7 @@ int LibV1::AP_width(mapStr2intVec& IntFeatureData,
   retval = __AP_width(t, v, stimstart[0], threshold[0], peakindices,
                       minahpindices, apwidth);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_width", apwidth);
+    setVec(DoubleFeatureData, StringData, "AP_width", apwidth);
   }
   return retval;
 }
@@ -1875,7 +1875,7 @@ int LibV1::doublet_ISI(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> doubletisi(1, pvt[1] - pvt[0]);
-  setDoubleVec(DoubleFeatureData, StringData, "doublet_ISI", doubletisi);
+  setVec(DoubleFeatureData, StringData, "doublet_ISI", doubletisi);
   return retval;
 }
 // end of doublet_ISI
@@ -1911,7 +1911,7 @@ int LibV1::AHP_depth(mapStr2intVec& IntFeatureData,
   vector<double> ahpdepth;
   retval = __AHP_depth(voltagebase, minahpvalues, ahpdepth);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AHP_depth", ahpdepth);
+    setVec(DoubleFeatureData, StringData, "AHP_depth", ahpdepth);
   }
   return retval;
 }
@@ -1947,7 +1947,7 @@ int LibV1::AP_amplitude_diff(mapStr2intVec& IntFeatureData,
   vector<double> apamplitudediff;
   retval = __AP_amplitude_diff(apamplitude, apamplitudediff);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_amplitude_diff",
+    setVec(DoubleFeatureData, StringData, "AP_amplitude_diff",
                  apamplitudediff);
   }
   return retval;
@@ -1983,7 +1983,7 @@ int LibV1::AHP_depth_diff(mapStr2intVec& IntFeatureData,
   vector<double> ahpdepthdiff;
   retval = __AHP_depth_diff(ahpdepth, ahpdepthdiff);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AHP_depth_diff", ahpdepthdiff);
+    setVec(DoubleFeatureData, StringData, "AHP_depth_diff", ahpdepthdiff);
   }
   return retval;
 }

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -56,10 +56,10 @@ int LibV1::interpolate(mapStr2intVec& IntFeatureData,
   vector<double> V, T, VIntrpol, TIntrpol, InterpStepVec;
   vector<int> intrpolte;
   double InterpStep;
-  // getDoubleVec takes care of stimulus suffix
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  // getVec takes care of stimulus suffix
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal <= 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", T);
+  retVal = getVec(DoubleFeatureData, StringData, "T", T);
   if (retVal <= 0) return -1;
   // interp_step is a stimulus independent parameter
   retVal = getDoubleParam(DoubleFeatureData, "interp_step", InterpStepVec);
@@ -126,7 +126,7 @@ int LibV1::peak_indices(mapStr2intVec& IntFeatureData,
     return nSize;
   vector<int> PeakIndex;
   vector<double> v, Th;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal <= 0) return -1;
   retVal = getDoubleParam(DoubleFeatureData, "Threshold", Th);
   if (retVal <= 0) return -1;
@@ -149,7 +149,7 @@ int LibV1::Spikecount(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<int> peakindices;
-  retval = getIntVec(IntFeatureData, StringData, "peak_indices",
+  retval = getVec(IntFeatureData, StringData, "peak_indices",
                      peakindices);
   if (retval < 0) {
     return -1;
@@ -177,7 +177,7 @@ int LibV1::ISI_values(mapStr2intVec& IntFeatureData,
     return nSize;
 
   vector<double> VecISI, pvTime;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", pvTime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", pvTime);
   if (retVal < 3) {
     GErrorStr += "\n Three spikes required for calculation of ISI_values.\n";
     return -1;
@@ -217,7 +217,7 @@ int LibV1::ISI_CV(mapStr2intVec& IntFeatureData,
   if (retval) return nsize;
 
   vector<double> isivalues;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "ISI_values",
+  retval = getVec(DoubleFeatureData, StringData, "ISI_values",
                         isivalues);
   if (retval < 2) return -1;
 
@@ -240,15 +240,15 @@ int LibV1::peak_voltage(mapStr2intVec& IntFeatureData,
   if (retVal)
     return nSize;
 
-  // vector<int> PeakI = getIntVec(IntFeatureData, StringData,
+  // vector<int> PeakI = getVec(IntFeatureData, StringData,
   // string("peak_indices"));
   vector<int> PeakI;
   vector<double> V, peakV;
 
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", PeakI);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", PeakI);
   if (retVal <= 0) return -1;
 
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal <= 0) return -1;
 
   for (size_t i = 0; i < PeakI.size(); i++) {
@@ -270,11 +270,11 @@ int LibV1::firing_rate(mapStr2intVec& IntFeatureData,
 
   vector<double> stimStart, stimEnd, peakVTime, firing_rate;
   double lastAPTime = 0.;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peakVTime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", peakVTime);
   if (retVal <= 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal <= 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal <= 0) return -1;
 
   int nCount = 0;
@@ -304,9 +304,9 @@ int LibV1::peak_time(mapStr2intVec& IntFeatureData,
 
   vector<int> PeakI;
   vector<double> T, pvTime;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", PeakI);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", PeakI);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", T);
+  retVal = getVec(DoubleFeatureData, StringData, "T", T);
   if (retVal < 0) return -1;
   for (size_t i = 0; i < PeakI.size(); i++) {
     pvTime.push_back(T[PeakI[i]]);
@@ -328,12 +328,12 @@ int LibV1::first_spike_time(mapStr2intVec& IntFeatureData,
   vector<double> first_spike;
   vector<double> peaktime;
   vector<double> stimstart;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peaktime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", peaktime);
   if (retVal < 1) {
     GErrorStr += "\n One spike required for time_to_first_spike.\n";
     return -1;
   }
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retVal <= 0) return -1;
   first_spike.push_back(peaktime[0] - stimstart[0]);
   setVec(DoubleFeatureData, StringData, "time_to_first_spike",
@@ -358,18 +358,18 @@ int LibV1::min_AHP_indices(mapStr2intVec& IntFeatureData,
   vector<double> min_ahp_values;
   vector<double> stim_end;
   vector<double> t;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal <= 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices",
+  retVal = getVec(IntFeatureData, StringData, "peak_indices",
                      peak_indices_plus);
   if (retVal < 1) {
     GErrorStr += "\n At least one spike required for calculation of "
         "min_AHP_indices.\n";
     return -1;
   }
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stim_end);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stim_end);
   if (retVal <= 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal <= 0) return -1;
 
   int end_index = distance(
@@ -411,7 +411,7 @@ int LibV1::AP_height(mapStr2intVec& IntFeatureData,
     return nSize;
 
   vector<double> vPeak;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_voltage", vPeak);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_voltage", vPeak);
   if (retVal <= 0) return -1;
   setVec(DoubleFeatureData, StringData, "AP_height", vPeak);
 
@@ -432,40 +432,40 @@ int LibV1::AP_amplitude(mapStr2intVec& IntFeatureData,
   vector<double> peaktime;
   vector<int> apbeginindices;
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal <= 0) {
     GErrorStr += "AP_amplitude: Can't find voltage vector V";
     return -1;
   }
 
   vector<double> stimstart;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retVal != 1) {
     GErrorStr += "AP_amplitude: Error getting stim_start";
     return -1;
   }
 
   vector<double> stimend;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimend);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimend);
   if (retVal != 1) {
     GErrorStr += "AP_amplitude: Error getting stim_end";
     return -1;
   }
 
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_voltage",
+  retVal = getVec(DoubleFeatureData, StringData, "peak_voltage",
                         peakvoltage);
   if (retVal <= 0) {
     GErrorStr += "AP_amplitude: Error calculating peak_voltage";
     return -1;
   }
 
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peaktime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", peaktime);
   if (retVal <= 0) {
     GErrorStr += "AP_amplitude: Error calculating peak_time";
     return -1;
   }
 
-  retVal = getIntVec(IntFeatureData, StringData, "AP_begin_indices",
+  retVal = getVec(IntFeatureData, StringData, "AP_begin_indices",
                      apbeginindices);
   if (retVal <= 0) {
     GErrorStr += "AP_amplitude: Error calculating AP_begin_indicies";
@@ -516,7 +516,7 @@ int LibV1::AHP_depth_abs(mapStr2intVec& IntFeatureData,
     return nSize;
 
   vector<double> vAHP;
-  retVal = getDoubleVec(DoubleFeatureData, StringData,
+  retVal = getVec(DoubleFeatureData, StringData,
                         "min_AHP_values", vAHP);
   if (retVal <= 0) return -1;
   setVec(DoubleFeatureData, StringData, "AHP_depth_abs", vAHP);
@@ -559,13 +559,13 @@ int LibV1::AHP_depth_abs_slow(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> t;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
   vector<double> v;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retval = getVec(DoubleFeatureData, StringData, "V", v);
   if (retval < 0) return -1;
   vector<int> peakindices;
-  retval = getIntVec(IntFeatureData, StringData, "peak_indices", peakindices);
+  retval = getVec(IntFeatureData, StringData, "peak_indices", peakindices);
   if (retval < 3) {
     GErrorStr += "\n At least 3 spikes needed for AHP_depth_abs_slow and "
         "AHP_slow_time.\n";
@@ -611,11 +611,11 @@ int LibV1::rest_voltage_value(mapStr2intVec& IntFeatureData,
 
   vector<double> v, t, stimStart, vRest;
   double startTime, endTime;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal < 0) return -1;
   startTime = stimStart[0] * .25;  // It is 25% from start (0), so if stimulus
                                    // starts at 100ms then StartTime will be
@@ -677,13 +677,13 @@ int LibV1::burst_ISI_indices(mapStr2intVec& IntFeatureData,
   vector<int> PeakIndex, BurstIndex;
   vector<double> ISIValues, tVec;
   double BurstFactor = 0;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
   if (retVal < 0) return -1;
   if (PeakIndex.size() < 5) {
     GErrorStr += "\nError: More than 5 spike is needed for burst calculation.\n";
     return -1;
   }
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "ISI_values", ISIValues);
+  retVal = getVec(DoubleFeatureData, StringData, "ISI_values", ISIValues);
   if (retVal < 0) return -1;
   retVal = getDoubleParam(DoubleFeatureData, "burst_factor", tVec);
   if (retVal < 0)
@@ -734,9 +734,9 @@ int LibV1::burst_mean_freq(mapStr2intVec& IntFeatureData,
 
   vector<int> BurstIndex;
   vector<double> BurstMeanFreq, PVTime;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", PVTime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", PVTime);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "burst_ISI_indices",
+  retVal = getVec(IntFeatureData, StringData, "burst_ISI_indices",
                      BurstIndex);
   if (retVal < 0) return -1;
 
@@ -759,7 +759,7 @@ int LibV1::burst_number(mapStr2intVec& IntFeatureData,
 
   vector<double> BurstMeanFreq;
   vector<int> BurstNum;
-  retVal = getDoubleVec(DoubleFeatureData, StringData,
+  retVal = getVec(DoubleFeatureData, StringData,
                         "burst_mean_freq", BurstMeanFreq);
   if (retVal < 0) return -1;
 
@@ -810,14 +810,14 @@ int LibV1::interburst_voltage(mapStr2intVec& IntFeatureData,
 
   vector<int> BurstIndex, PeakIndex;
   vector<double> V, T, IBV;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", T);
+  retVal = getVec(DoubleFeatureData, StringData, "T", T);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "burst_ISI_indices",
+  retVal = getVec(IntFeatureData, StringData, "burst_ISI_indices",
                      BurstIndex);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal < 0) return -1;
 
   retVal = __interburst_voltage(BurstIndex, PeakIndex, T, V, IBV);
@@ -894,11 +894,11 @@ int LibV1::adaptation_index(mapStr2intVec& IntFeatureData,
       adaptation_index;
   vector<int> maxnSpike;
   double Offset;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peakVTime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", peakVTime);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal < 0) return -1;
   retVal = getDoubleParam(DoubleFeatureData, "spike_skipf", spikeSkipf);
   if (retVal < 0) return -1;
@@ -981,19 +981,19 @@ int LibV1::adaptation_index2(mapStr2intVec& IntFeatureData,
   if (retval) return nsize;
 
   vector<double> peakvoltagetime;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_time",
+  retval = getVec(DoubleFeatureData, StringData, "peak_time",
                         peakvoltagetime);
   if (retval < 4) {
     GErrorStr += "\n At least 4 spikes needed for adaptation_index2.\n";
     return -1;
   }
   vector<double> stimStart;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retval = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   {
     if (retval < 0) return -1;
   };
   vector<double> stimEnd;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retval = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   {
     if (retval < 0) return -1;
   };
@@ -1028,11 +1028,11 @@ int LibV1::trace_check(mapStr2intVec& IntFeatureData,
   vector<double> stim_start;
   vector<double> stim_end;
   vector<int> tc;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peak_time);
+  retval = getVec(DoubleFeatureData, StringData, "peak_time", peak_time);
   if (retval < 0) return -1;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stim_start);
+  retval = getVec(DoubleFeatureData, StringData, "stim_start", stim_start);
   if (retval < 0) return -1;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stim_end);
+  retval = getVec(DoubleFeatureData, StringData, "stim_end", stim_end);
   if (retval < 0) return -1;
 
   bool sane = true;
@@ -1148,13 +1148,13 @@ int LibV1::spike_width2(mapStr2intVec& IntFeatureData,
 
   vector<int> PeakIndex, minAHPIndex;
   vector<double> V, t, dv1, dv2, spike_width2;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndex);
+  retVal = getVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndex);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
   if (retVal < 0) return -1;
   if (PeakIndex.size() <= 1) {
     GErrorStr += "\nError: More than one spike is needed for spikewidth "
@@ -1225,15 +1225,15 @@ int LibV1::spike_width1(mapStr2intVec& IntFeatureData,
   vector<int> PeakIndex, minAHPIndex;
   vector<double> V, t, dv1, dv2, spike_width1;
   vector<double> stim_start;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stim_start);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stim_start);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndex);
+  retVal = getVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndex);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
   if (retVal < 0) return -1;
   if (PeakIndex.size() <= 1) {
     GErrorStr += "\nError: More than one spike is needed for spikewidth "
@@ -1409,13 +1409,13 @@ int LibV1::time_constant(mapStr2intVec& IntFeatureData,
   vector<double> t;
   vector<double> stimStart;
   vector<double> stimEnd;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal < 0) return -1;
   vector<double> tc;
   retVal = __time_constant(v, t, stimStart[0], stimEnd[0], tc);
@@ -1475,13 +1475,13 @@ int LibV1::voltage_deflection(mapStr2intVec& IntFeatureData,
   vector<double> t;
   vector<double> stimStart;
   vector<double> stimEnd;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal < 0) return -1;
   vector<double> vd;
   retVal = __voltage_deflection(v, t, stimStart[0], stimEnd[0], vd);
@@ -1511,7 +1511,7 @@ int LibV1::ohmic_input_resistance(mapStr2intVec& IntFeatureData,
     return nSize;
 
   vector<double> voltage_deflection;
-  retVal = getDoubleVec(DoubleFeatureData, StringData,
+  retVal = getVec(DoubleFeatureData, StringData,
                         "voltage_deflection", voltage_deflection);
   if (retVal < 0) return -1;
   vector<double> stimulus_current;
@@ -1577,13 +1577,13 @@ int LibV1::maximum_voltage(mapStr2intVec& IntFeatureData,
   vector<double> t;
   vector<double> stimStart;
   vector<double> stimEnd;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal < 0) return -1;
 
   vector<double> maxV, minV;
@@ -1610,13 +1610,13 @@ int LibV1::minimum_voltage(mapStr2intVec& IntFeatureData,
   vector<double> t;
   vector<double> stimStart;
   vector<double> stimEnd;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal < 0) return -1;
   vector<double> maxV, minV;
   retVal = __maxmin_voltage(v, t, stimStart[0], stimEnd[0], maxV, minV);
@@ -1652,13 +1652,13 @@ int LibV1::steady_state_voltage(mapStr2intVec& IntFeatureData,
     return nSize;
 
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 1) return -1;
   vector<double> t;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 1) return -1;
   vector<double> stimEnd;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal != 1) return -1;
 
   vector<double> ssv;
@@ -1699,7 +1699,7 @@ int LibV1::single_burst_ratio(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> isivalues;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "ISI_values", isivalues);
+  retval = getVec(DoubleFeatureData, StringData, "ISI_values", isivalues);
   if (retval < 0) return -1;
   vector<double> singleburstratio;
 
@@ -1823,26 +1823,26 @@ int LibV1::AP_width(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> t;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
   vector<double> v;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retval = getVec(DoubleFeatureData, StringData, "V", v);
   if (retval < 0) return -1;
   vector<double> threshold;
   retval = getDoubleParam(DoubleFeatureData, "Threshold", threshold);
   if (retval < 0) return -1;
   vector<double> stimstart;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retval = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retval < 0) return -1;
   vector<int> peakindices;
-  retval = getIntVec(IntFeatureData, StringData, "peak_indices", peakindices);
+  retval = getVec(IntFeatureData, StringData, "peak_indices", peakindices);
   if (retval <= 0) {
     GErrorStr += "\nNo spike in trace.\n";
     return -1;
   }
 
   vector<int> minahpindices;
-  retval = getIntVec(IntFeatureData, StringData, "min_AHP_indices", minahpindices);
+  retval = getVec(IntFeatureData, StringData, "min_AHP_indices", minahpindices);
   if (retval < 0) return -1;
   vector<double> apwidth;
   retval = __AP_width(t, v, stimstart[0], threshold[0], peakindices,
@@ -1868,7 +1868,7 @@ int LibV1::doublet_ISI(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> pvt;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_time", pvt);
+  retval = getVec(DoubleFeatureData, StringData, "peak_time", pvt);
   if (retval < 2) {
     GErrorStr += "\nNeed at least two spikes for doublet_ISI.\n";
     return -1;
@@ -1900,11 +1900,11 @@ int LibV1::AHP_depth(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> voltagebase;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "voltage_base",
+  retval = getVec(DoubleFeatureData, StringData, "voltage_base",
                         voltagebase);
   if (retval < 0) return -1;
   vector<double> minahpvalues;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "min_AHP_values",
+  retval = getVec(DoubleFeatureData, StringData, "min_AHP_values",
                         minahpvalues);
   if (retval < 0) return -1;
 
@@ -1940,7 +1940,7 @@ int LibV1::AP_amplitude_diff(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> apamplitude;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "AP_amplitude",
+  retval = getVec(DoubleFeatureData, StringData, "AP_amplitude",
                         apamplitude);
   if (retval < 0) return -1;
 
@@ -1976,7 +1976,7 @@ int LibV1::AHP_depth_diff(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> ahpdepth;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "AHP_depth",
+  retval = getVec(DoubleFeatureData, StringData, "AHP_depth",
                         ahpdepth);
   if (retval < 0) return -1;
 

--- a/efel/cppcore/LibV2.cpp
+++ b/efel/cppcore/LibV2.cpp
@@ -126,7 +126,7 @@ int LibV2::AP_begin_indices(mapStr2intVec& IntFeatureData,
   vector<int> apbi;
   retVal = __AP_begin_indices(t, v, stimstart[0], stimend[0], ahpi, apbi);
   if (retVal >= 0) {
-    setIntVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
+    setVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
   }
   return retVal;
 }
@@ -177,7 +177,7 @@ int LibV2::AP_end_indices(mapStr2intVec& IntFeatureData,
   vector<int> apei;
   retVal = __AP_end_indices(t, v, pi, apei);
   if (retVal >= 0) {
-    setIntVec(IntFeatureData, StringData, "AP_end_indices", apei);
+    setVec(IntFeatureData, StringData, "AP_end_indices", apei);
   }
   return retVal;
 }
@@ -228,7 +228,7 @@ int LibV2::AP_rise_indices(mapStr2intVec& IntFeatureData,
   vector<int> apri;
   retVal = __AP_rise_indices(v, apbi, pi, apri);
   if (retVal >= 0) {
-    setIntVec(IntFeatureData, StringData, "AP_rise_indices", apri);
+    setVec(IntFeatureData, StringData, "AP_rise_indices", apri);
   }
   return retVal;
 }
@@ -276,7 +276,7 @@ int LibV2::AP_fall_indices(mapStr2intVec& IntFeatureData,
   vector<int> apfi;
   retVal = __AP_fall_indices(v, apbi, apei, pi, apfi);
   if (retVal >= 0) {
-    setIntVec(IntFeatureData, StringData, "AP_fall_indices", apfi);
+    setVec(IntFeatureData, StringData, "AP_fall_indices", apfi);
   }
   return retVal;
 }
@@ -319,7 +319,7 @@ int LibV2::AP_duration(mapStr2intVec& IntFeatureData,
   vector<double> apduration;
   retval = __AP_duration(t, apbeginindices, endindices, apduration);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_duration", apduration);
+    setVec(DoubleFeatureData, StringData, "AP_duration", apduration);
   }
   return retval;
 }
@@ -361,7 +361,7 @@ int LibV2::AP_duration_half_width(mapStr2intVec& IntFeatureData,
   retval = __AP_duration_half_width(t, apriseindices, apfallindices,
                                     apdurationhalfwidth);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_duration_half_width",
+    setVec(DoubleFeatureData, StringData, "AP_duration_half_width",
                  apdurationhalfwidth);
   }
   return retval;
@@ -403,7 +403,7 @@ int LibV2::AP_rise_time(mapStr2intVec& IntFeatureData,
   vector<double> aprisetime;
   retval = __AP_rise_time(t, apbeginindices, peakindices, aprisetime);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_rise_time", aprisetime);
+    setVec(DoubleFeatureData, StringData, "AP_rise_time", aprisetime);
   }
   return retval;
 }
@@ -444,7 +444,7 @@ int LibV2::AP_fall_time(mapStr2intVec& IntFeatureData,
   vector<double> apfalltime;
   retval = __AP_fall_time(t, peakindices, apendindices, apfalltime);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_fall_time", apfalltime);
+    setVec(DoubleFeatureData, StringData, "AP_fall_time", apfalltime);
   }
   return retval;
 }
@@ -489,7 +489,7 @@ int LibV2::AP_rise_rate(mapStr2intVec& IntFeatureData,
   vector<double> apriserate;
   retval = __AP_rise_rate(t, v, apbeginindices, peakindices, apriserate);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_rise_rate", apriserate);
+    setVec(DoubleFeatureData, StringData, "AP_rise_rate", apriserate);
   }
   return retval;
 }
@@ -533,7 +533,7 @@ int LibV2::AP_fall_rate(mapStr2intVec& IntFeatureData,
   vector<double> apfallrate;
   retval = __AP_fall_rate(t, v, peakindices, apendindices, apfallrate);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_fall_rate", apfallrate);
+    setVec(DoubleFeatureData, StringData, "AP_fall_rate", apfallrate);
   }
   return retval;
 }
@@ -576,7 +576,7 @@ int LibV2::fast_AHP(mapStr2intVec& IntFeatureData,
   vector<double> fastahp;
   retval = __fast_AHP(v, apbeginindices, minahpindices, fastahp);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "fast_AHP", fastahp);
+    setVec(DoubleFeatureData, StringData, "fast_AHP", fastahp);
   }
   return retval;
 }
@@ -612,7 +612,7 @@ int LibV2::AP_amplitude_change(mapStr2intVec& IntFeatureData,
   vector<double> apamplitudechange;
   retval = __AP_amplitude_change(apamplitude, apamplitudechange);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_amplitude_change",
+    setVec(DoubleFeatureData, StringData, "AP_amplitude_change",
                  apamplitudechange);
   }
   return retval;
@@ -648,7 +648,7 @@ int LibV2::AP_duration_change(mapStr2intVec& IntFeatureData,
   vector<double> apdurationchange;
   retval = __AP_duration_change(apduration, apdurationchange);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_duration_change",
+    setVec(DoubleFeatureData, StringData, "AP_duration_change",
                  apdurationchange);
   }
   return retval;
@@ -688,7 +688,7 @@ int LibV2::AP_duration_half_width_change(mapStr2intVec& IntFeatureData,
   retval = __AP_duration_half_width_change(apdurationhalfwidth,
                                            apdurationhalfwidthchange);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_duration_half_width_change",
+    setVec(DoubleFeatureData, StringData, "AP_duration_half_width_change",
                  apdurationhalfwidthchange);
   }
   return retval;
@@ -725,7 +725,7 @@ int LibV2::AP_rise_rate_change(mapStr2intVec& IntFeatureData,
   vector<double> apriseratechange;
   retval = __AP_rise_rate_change(apriserate, apriseratechange);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_rise_rate_change",
+    setVec(DoubleFeatureData, StringData, "AP_rise_rate_change",
                  apriseratechange);
   }
   return retval;
@@ -761,7 +761,7 @@ int LibV2::AP_fall_rate_change(mapStr2intVec& IntFeatureData,
   vector<double> apfallratechange;
   retval = __AP_fall_rate_change(apfallrate, apfallratechange);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_fall_rate_change",
+    setVec(DoubleFeatureData, StringData, "AP_fall_rate_change",
                  apfallratechange);
   }
   return retval;
@@ -796,7 +796,7 @@ int LibV2::fast_AHP_change(mapStr2intVec& IntFeatureData,
   vector<double> fastahpchange;
   retval = __fast_AHP_change(fastahp, fastahpchange);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "fast_AHP_change",
+    setVec(DoubleFeatureData, StringData, "fast_AHP_change",
                  fastahpchange);
   }
   return retval;
@@ -817,7 +817,7 @@ int LibV2::E6(mapStr2intVec& IntFeatureData,
                               0, e6);
   if (retval >= 0) {
     e6.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E6", e6);
+    setVec(DoubleFeatureData, StringData, "E6", e6);
   }
   return retval;
 }
@@ -837,7 +837,7 @@ int LibV2::E7(mapStr2intVec& IntFeatureData,
       mean_traces_double(DoubleFeatureData, "AP_duration", "APWaveForm", 0, e7);
   if (retval >= 0) {
     e7.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E7", e7);
+    setVec(DoubleFeatureData, StringData, "E7", e7);
   }
   return retval;
 }
@@ -882,7 +882,7 @@ int LibV2::BPAPatt2(mapStr2intVec& IntFeatureData,
   // action potential:
   // the height of the dendritic spike
   bpapatt.push_back(*max_element(v_dend.begin(), v_dend.end()) - vb_dend[0]);
-  setDoubleVec(DoubleFeatureData, StringData, "BPAPatt2", bpapatt);
+  setVec(DoubleFeatureData, StringData, "BPAPatt2", bpapatt);
   return retval;
 }
 // end of BPAPatt2
@@ -926,7 +926,7 @@ int LibV2::BPAPatt3(mapStr2intVec& IntFeatureData,
   // action potential:
   // the height of the dendritic spike
   bpapatt.push_back(*max_element(v_dend.begin(), v_dend.end()) - vb_dend[0]);
-  setDoubleVec(DoubleFeatureData, StringData, "BPAPatt3", bpapatt);
+  setVec(DoubleFeatureData, StringData, "BPAPatt3", bpapatt);
   return retval;
 }
 // end of BPAPatt3
@@ -967,8 +967,8 @@ int LibV2::E39(mapStr2intVec& IntFeatureData,
     fit = slope_straight_line_fit(current, frequency);
     vector<double> e39(1, fit.slope);
     vector<double> e39_cod(1, fit.r_square);
-    setDoubleVec(DoubleFeatureData, StringData, "E39", e39);
-    setDoubleVec(DoubleFeatureData, StringData, "E39_cod", e39_cod);
+    setVec(DoubleFeatureData, StringData, "E39", e39);
+    setVec(DoubleFeatureData, StringData, "E39_cod", e39_cod);
     return e39.size();
   }
   GErrorStr += "\nMore than 1 trace required for calculation of E39";
@@ -1016,7 +1016,7 @@ int LibV2::amp_drop_first_second(mapStr2intVec& IntFeatureData,
   vector<double> ampdropfirstsecond;
   retval = __amp_drop_first_second(peakvoltage, ampdropfirstsecond);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "amp_drop_first_second",
+    setVec(DoubleFeatureData, StringData, "amp_drop_first_second",
                  ampdropfirstsecond);
   }
   return retval;
@@ -1036,7 +1036,7 @@ int LibV2::E2(mapStr2intVec& IntFeatureData,
   retval = mean_traces_double(DoubleFeatureData, "amp_drop_first_second",
                               "APDrop", 0, e2);
   if (retval > 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "E2", e2);
+    setVec(DoubleFeatureData, StringData, "E2", e2);
     return 1;
   }
   return retval;
@@ -1070,7 +1070,7 @@ int LibV2::amp_drop_first_last(mapStr2intVec& IntFeatureData,
   vector<double> ampdropfirstlast;
   retval = __amp_drop_first_last(peakvoltage, ampdropfirstlast);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "amp_drop_first_last",
+    setVec(DoubleFeatureData, StringData, "amp_drop_first_last",
                  ampdropfirstlast);
   }
   return retval;
@@ -1090,7 +1090,7 @@ int LibV2::E3(mapStr2intVec& IntFeatureData,
   retval = mean_traces_double(DoubleFeatureData, "amp_drop_first_last",
                               "APDrop", 0, e3);
   if (retval > 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "E3", e3);
+    setVec(DoubleFeatureData, StringData, "E3", e3);
     return 1;
   }
   return retval;
@@ -1124,7 +1124,7 @@ int LibV2::amp_drop_second_last(mapStr2intVec& IntFeatureData,
   vector<double> ampdropsecondlast;
   retval = __amp_drop_second_last(peakvoltage, ampdropsecondlast);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "amp_drop_second_last",
+    setVec(DoubleFeatureData, StringData, "amp_drop_second_last",
                  ampdropsecondlast);
   }
   return retval;
@@ -1144,7 +1144,7 @@ int LibV2::E4(mapStr2intVec& IntFeatureData,
   retval = mean_traces_double(DoubleFeatureData, "amp_drop_second_last",
                               "APDrop", 0, e4);
   if (retval > 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "E4", e4);
+    setVec(DoubleFeatureData, StringData, "E4", e4);
     return 1;
   }
   return retval;
@@ -1188,7 +1188,7 @@ int LibV2::max_amp_difference(mapStr2intVec& IntFeatureData,
   vector<double> maxampdifference;
   retval = __max_amp_difference(peakvoltage, maxampdifference);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "max_amp_difference",
+    setVec(DoubleFeatureData, StringData, "max_amp_difference",
                  maxampdifference);
   }
   return retval;
@@ -1208,7 +1208,7 @@ int LibV2::E5(mapStr2intVec& IntFeatureData,
   retval = mean_traces_double(DoubleFeatureData, "max_amp_difference", "APDrop",
                               0, e5);
   if (retval > 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "E5", e5);
+    setVec(DoubleFeatureData, StringData, "E5", e5);
     return 1;
   }
   return retval;
@@ -1229,7 +1229,7 @@ int LibV2::E8(mapStr2intVec& IntFeatureData,
                               "APWaveForm", 0, e8);
   if (retval >= 0) {
     e8.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E8", e8);
+    setVec(DoubleFeatureData, StringData, "E8", e8);
   }
   return retval;
 }
@@ -1249,7 +1249,7 @@ int LibV2::E9(mapStr2intVec& IntFeatureData,
                               0, e9);
   if (retval >= 0) {
     e9.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E9", e9);
+    setVec(DoubleFeatureData, StringData, "E9", e9);
   }
   return retval;
 }
@@ -1270,7 +1270,7 @@ int LibV2::E10(mapStr2intVec& IntFeatureData,
                               0, e10);
   if (retval >= 0) {
     e10.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E10", e10);
+    setVec(DoubleFeatureData, StringData, "E10", e10);
   }
   return retval;
 }
@@ -1291,7 +1291,7 @@ int LibV2::E11(mapStr2intVec& IntFeatureData,
                               0, e11);
   if (retval >= 0) {
     e11.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E11", e11);
+    setVec(DoubleFeatureData, StringData, "E11", e11);
   }
   return retval;
 }
@@ -1312,7 +1312,7 @@ int LibV2::E12(mapStr2intVec& IntFeatureData,
                               0, e12);
   if (retval >= 0) {
     e12.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E12", e12);
+    setVec(DoubleFeatureData, StringData, "E12", e12);
   }
   return retval;
 }
@@ -1333,7 +1333,7 @@ int LibV2::E13(mapStr2intVec& IntFeatureData,
       mean_traces_double(DoubleFeatureData, "fast_AHP", "APWaveForm", 0, e13);
   if (retval >= 0) {
     e13.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E13", e13);
+    setVec(DoubleFeatureData, StringData, "E13", e13);
   }
   return retval;
 }
@@ -1355,7 +1355,7 @@ int LibV2::E14(mapStr2intVec& IntFeatureData,
   if (retval >= 0) {
     e14[0] = e14[1];
     e14.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E14", e14);
+    setVec(DoubleFeatureData, StringData, "E14", e14);
   }
   return retval;
 }
@@ -1377,7 +1377,7 @@ int LibV2::E15(mapStr2intVec& IntFeatureData,
   if (retval >= 0) {
     e15[0] = e15[1];
     e15.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E15", e15);
+    setVec(DoubleFeatureData, StringData, "E15", e15);
   }
   return retval;
 }
@@ -1399,7 +1399,7 @@ int LibV2::E16(mapStr2intVec& IntFeatureData,
   if (retval >= 0) {
     e16[0] = e16[1];
     e16.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E16", e16);
+    setVec(DoubleFeatureData, StringData, "E16", e16);
   }
   return retval;
 }
@@ -1421,7 +1421,7 @@ int LibV2::E17(mapStr2intVec& IntFeatureData,
   if (retval >= 0) {
     e17[0] = e17[1];
     e17.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E17", e17);
+    setVec(DoubleFeatureData, StringData, "E17", e17);
   }
   return retval;
 }
@@ -1443,7 +1443,7 @@ int LibV2::E18(mapStr2intVec& IntFeatureData,
   if (retval >= 0) {
     e18[0] = e18[1];
     e18.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E18", e18);
+    setVec(DoubleFeatureData, StringData, "E18", e18);
   }
   return retval;
 }
@@ -1465,7 +1465,7 @@ int LibV2::E19(mapStr2intVec& IntFeatureData,
   if (retval >= 0) {
     e19[0] = e19[1];
     e19.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E19", e19);
+    setVec(DoubleFeatureData, StringData, "E19", e19);
   }
   return retval;
 }
@@ -1487,7 +1487,7 @@ int LibV2::E20(mapStr2intVec& IntFeatureData,
   if (retval >= 0) {
     e20[0] = e20[1];
     e20.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E20", e20);
+    setVec(DoubleFeatureData, StringData, "E20", e20);
   }
   return retval;
 }
@@ -1509,7 +1509,7 @@ int LibV2::E21(mapStr2intVec& IntFeatureData,
   if (retval >= 0) {
     e21[0] = e21[1];
     e21.resize(1);
-    setDoubleVec(DoubleFeatureData, StringData, "E21", e21);
+    setVec(DoubleFeatureData, StringData, "E21", e21);
   }
   return retval;
 }
@@ -1529,7 +1529,7 @@ int LibV2::E22(mapStr2intVec& IntFeatureData,
   retval = mean_traces_double(DoubleFeatureData, "AP_amplitude_change",
                               "APWaveForm", 0, e22);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "E22", e22);
+    setVec(DoubleFeatureData, StringData, "E22", e22);
   }
   return retval;
 }
@@ -1549,7 +1549,7 @@ int LibV2::E23(mapStr2intVec& IntFeatureData,
   retval = mean_traces_double(DoubleFeatureData, "AP_duration_change",
                               "APWaveForm", 0, e23);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "E23", e23);
+    setVec(DoubleFeatureData, StringData, "E23", e23);
   }
   return retval;
 }
@@ -1569,7 +1569,7 @@ int LibV2::E24(mapStr2intVec& IntFeatureData,
   retval = mean_traces_double(
       DoubleFeatureData, "AP_duration_half_width_change", "APWaveForm", 0, e24);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "E24", e24);
+    setVec(DoubleFeatureData, StringData, "E24", e24);
   }
   return retval;
 }
@@ -1589,7 +1589,7 @@ int LibV2::E25(mapStr2intVec& IntFeatureData,
   retval = mean_traces_double(DoubleFeatureData, "AP_rise_rate_change",
                               "APWaveForm", 0, e25);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "E25", e25);
+    setVec(DoubleFeatureData, StringData, "E25", e25);
   }
   return retval;
 }
@@ -1609,7 +1609,7 @@ int LibV2::E26(mapStr2intVec& IntFeatureData,
   retval = mean_traces_double(DoubleFeatureData, "AP_fall_rate_change",
                               "APWaveForm", 0, e26);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "E26", e26);
+    setVec(DoubleFeatureData, StringData, "E26", e26);
   }
   return retval;
 }
@@ -1629,7 +1629,7 @@ int LibV2::E27(mapStr2intVec& IntFeatureData,
   retval = mean_traces_double(DoubleFeatureData, "fast_AHP_change",
                               "APWaveForm", 0, e27);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "E27", e27);
+    setVec(DoubleFeatureData, StringData, "E27", e27);
   }
   return retval;
 }
@@ -1686,7 +1686,7 @@ int LibV2::steady_state_hyper(mapStr2intVec& IntFeatureData,
   vector<double> steady_state_hyper;
   retval = __steady_state_hyper(v, t, stimend[0], steady_state_hyper);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "steady_state_hyper",
+    setVec(DoubleFeatureData, StringData, "steady_state_hyper",
                  steady_state_hyper);
   }
   return retval;
@@ -1706,7 +1706,7 @@ int LibV2::E40(mapStr2intVec& IntFeatureData,
   retval = mean_traces_double(DoubleFeatureData, "time_to_first_spike",
                               "IDrest", 0, e40);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "E40", e40);
+    setVec(DoubleFeatureData, StringData, "E40", e40);
   }
   return retval;
 }

--- a/efel/cppcore/LibV2.cpp
+++ b/efel/cppcore/LibV2.cpp
@@ -109,19 +109,19 @@ int LibV2::AP_begin_indices(mapStr2intVec& IntFeatureData,
     return nSize;
   }
   vector<double> t;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
   vector<double> stimstart;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retVal < 0) return -1;
   vector<double> stimend;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimend);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimend);
   if (retVal < 0) return -1;
   vector<int> ahpi;
-  retVal = getIntVec(IntFeatureData, StringData, "min_AHP_indices", ahpi);
+  retVal = getVec(IntFeatureData, StringData, "min_AHP_indices", ahpi);
   if (retVal < 0) return -1;
   vector<int> apbi;
   retVal = __AP_begin_indices(t, v, stimstart[0], stimend[0], ahpi, apbi);
@@ -166,13 +166,13 @@ int LibV2::AP_end_indices(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> t;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
   vector<int> pi;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", pi);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", pi);
   if (retVal < 0) return -1;
   vector<int> apei;
   retVal = __AP_end_indices(t, v, pi, apei);
@@ -217,13 +217,13 @@ int LibV2::AP_rise_indices(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
   vector<int> apbi;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
+  retVal = getVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
   if (retVal < 0) return -1;
   vector<int> pi;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", pi);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", pi);
   if (retVal < 0) return -1;
   vector<int> apri;
   retVal = __AP_rise_indices(v, apbi, pi, apri);
@@ -262,16 +262,16 @@ int LibV2::AP_fall_indices(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
   vector<int> apbi;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
+  retVal = getVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
   if (retVal < 0) return -1;
   vector<int> apei;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_end_indices", apei);
+  retVal = getVec(IntFeatureData, StringData, "AP_end_indices", apei);
   if (retVal < 0) return -1;
   vector<int> pi;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", pi);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", pi);
   if (retVal < 0) return -1;
   vector<int> apfi;
   retVal = __AP_fall_indices(v, apbi, apei, pi, apfi);
@@ -306,14 +306,14 @@ int LibV2::AP_duration(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> t;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
   vector<int> apbeginindices;
-  retval = getIntVec(IntFeatureData, StringData, "AP_begin_indices",
+  retval = getVec(IntFeatureData, StringData, "AP_begin_indices",
                      apbeginindices);
   if (retval < 0) return -1;
   vector<int> endindices;
-  retval = getIntVec(IntFeatureData, StringData, "AP_end_indices",
+  retval = getVec(IntFeatureData, StringData, "AP_end_indices",
                      endindices);
   if (retval < 0) return -1;
   vector<double> apduration;
@@ -347,14 +347,14 @@ int LibV2::AP_duration_half_width(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> t;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
   vector<int> apriseindices;
-  retval = getIntVec(IntFeatureData, StringData, "AP_rise_indices",
+  retval = getVec(IntFeatureData, StringData, "AP_rise_indices",
                      apriseindices);
   if (retval < 0) return -1;
   vector<int> apfallindices;
-  retval = getIntVec(IntFeatureData, StringData, "AP_fall_indices",
+  retval = getVec(IntFeatureData, StringData, "AP_fall_indices",
                      apfallindices);
   if (retval < 0) return -1;
   vector<double> apdurationhalfwidth;
@@ -390,14 +390,14 @@ int LibV2::AP_rise_time(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> t;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
   vector<int> apbeginindices;
-  retval = getIntVec(IntFeatureData, StringData, "AP_begin_indices",
+  retval = getVec(IntFeatureData, StringData, "AP_begin_indices",
                      apbeginindices);
   if (retval < 0) return -1;
   vector<int> peakindices;
-  retval = getIntVec(IntFeatureData, StringData, "peak_indices",
+  retval = getVec(IntFeatureData, StringData, "peak_indices",
                      peakindices);
   if (retval < 0) return -1;
   vector<double> aprisetime;
@@ -431,14 +431,14 @@ int LibV2::AP_fall_time(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> t;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
   vector<int> peakindices;
-  retval = getIntVec(IntFeatureData, StringData, "peak_indices",
+  retval = getVec(IntFeatureData, StringData, "peak_indices",
                      peakindices);
   if (retval < 0) return -1;
   vector<int> apendindices;
-  retval = getIntVec(IntFeatureData, StringData, "AP_end_indices",
+  retval = getVec(IntFeatureData, StringData, "AP_end_indices",
                      apendindices);
   if (retval < 0) return -1;
   vector<double> apfalltime;
@@ -473,17 +473,17 @@ int LibV2::AP_rise_rate(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> t;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
   vector<double> v;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retval = getVec(DoubleFeatureData, StringData, "V", v);
   if (retval < 0) return -1;
   vector<int> apbeginindices;
-  retval = getIntVec(IntFeatureData, StringData, "AP_begin_indices",
+  retval = getVec(IntFeatureData, StringData, "AP_begin_indices",
                      apbeginindices);
   if (retval < 0) return -1;
   vector<int> peakindices;
-  retval = getIntVec(IntFeatureData, StringData, "peak_indices",
+  retval = getVec(IntFeatureData, StringData, "peak_indices",
                      peakindices);
   if (retval < 0) return -1;
   vector<double> apriserate;
@@ -518,16 +518,16 @@ int LibV2::AP_fall_rate(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> t;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
   vector<double> v;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retval = getVec(DoubleFeatureData, StringData, "V", v);
   if (retval < 0) return -1;
   vector<int> peakindices;
-  retval = getIntVec(IntFeatureData, StringData, "peak_indices", peakindices);
+  retval = getVec(IntFeatureData, StringData, "peak_indices", peakindices);
   if (retval < 0) return -1;
   vector<int> apendindices;
-  retval = getIntVec(IntFeatureData, StringData, "AP_end_indices",
+  retval = getVec(IntFeatureData, StringData, "AP_end_indices",
                      apendindices);
   if (retval < 0) return -1;
   vector<double> apfallrate;
@@ -563,14 +563,14 @@ int LibV2::fast_AHP(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> v;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retval = getVec(DoubleFeatureData, StringData, "V", v);
   if (retval < 0) return -1;
   vector<int> apbeginindices;
-  retval = getIntVec(IntFeatureData, StringData, "AP_begin_indices",
+  retval = getVec(IntFeatureData, StringData, "AP_begin_indices",
                      apbeginindices);
   if (retval < 0) return -1;
   vector<int> minahpindices;
-  retval = getIntVec(IntFeatureData, StringData, "min_AHP_indices",
+  retval = getVec(IntFeatureData, StringData, "min_AHP_indices",
                      minahpindices);
   if (retval < 0) return -1;
   vector<double> fastahp;
@@ -606,7 +606,7 @@ int LibV2::AP_amplitude_change(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> apamplitude;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "AP_amplitude",
+  retval = getVec(DoubleFeatureData, StringData, "AP_amplitude",
                         apamplitude);
   if (retval < 0) return -1;
   vector<double> apamplitudechange;
@@ -642,7 +642,7 @@ int LibV2::AP_duration_change(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> apduration;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "AP_duration",
+  retval = getVec(DoubleFeatureData, StringData, "AP_duration",
                         apduration);
   if (retval < 0) return -1;
   vector<double> apdurationchange;
@@ -681,7 +681,7 @@ int LibV2::AP_duration_half_width_change(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> apdurationhalfwidth;
-  retval = getDoubleVec(DoubleFeatureData, StringData,
+  retval = getVec(DoubleFeatureData, StringData,
                         "AP_duration_half_width", apdurationhalfwidth);
   if (retval < 0) return -1;
   vector<double> apdurationhalfwidthchange;
@@ -719,7 +719,7 @@ int LibV2::AP_rise_rate_change(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> apriserate;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "AP_rise_rate",
+  retval = getVec(DoubleFeatureData, StringData, "AP_rise_rate",
                         apriserate);
   if (retval < 0) return -1;
   vector<double> apriseratechange;
@@ -755,7 +755,7 @@ int LibV2::AP_fall_rate_change(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> apfallrate;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "AP_fall_rate",
+  retval = getVec(DoubleFeatureData, StringData, "AP_fall_rate",
                         apfallrate);
   if (retval < 0) return -1;
   vector<double> apfallratechange;
@@ -791,7 +791,7 @@ int LibV2::fast_AHP_change(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> fastahp;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "fast_AHP", fastahp);
+  retval = getVec(DoubleFeatureData, StringData, "fast_AHP", fastahp);
   if (retval < 0) return -1;
   vector<double> fastahpchange;
   retval = __fast_AHP_change(fastahp, fastahpchange);
@@ -1006,7 +1006,7 @@ int LibV2::amp_drop_first_second(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> peakvoltage;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_voltage",
+  retval = getVec(DoubleFeatureData, StringData, "peak_voltage",
                         peakvoltage);
   if (retval < 2) {
     GErrorStr +=
@@ -1060,7 +1060,7 @@ int LibV2::amp_drop_first_last(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> peakvoltage;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_voltage",
+  retval = getVec(DoubleFeatureData, StringData, "peak_voltage",
                         peakvoltage);
   if (retval < 2) {
     GErrorStr +=
@@ -1114,7 +1114,7 @@ int LibV2::amp_drop_second_last(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> peakvoltage;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_voltage",
+  retval = getVec(DoubleFeatureData, StringData, "peak_voltage",
                         peakvoltage);
   if (retval < 3) {
     GErrorStr +=
@@ -1178,7 +1178,7 @@ int LibV2::max_amp_difference(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> peakvoltage;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_voltage",
+  retval = getVec(DoubleFeatureData, StringData, "peak_voltage",
                         peakvoltage);
   if (retval < 2) {
     GErrorStr +=
@@ -1675,13 +1675,13 @@ int LibV2::steady_state_hyper(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> v;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retval = getVec(DoubleFeatureData, StringData, "V", v);
   if (retval < 0) return -1;
   vector<double> t;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
   vector<double> stimend;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimend);
+  retval = getVec(DoubleFeatureData, StringData, "stim_end", stimend);
   if (retval < 0) return -1;
   vector<double> steady_state_hyper;
   retval = __steady_state_hyper(v, t, stimend[0], steady_state_hyper);

--- a/efel/cppcore/LibV2.cpp
+++ b/efel/cppcore/LibV2.cpp
@@ -103,7 +103,7 @@ int LibV2::AP_begin_indices(mapStr2intVec& IntFeatureData,
                             mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "AP_begin_indices",
+  retVal = CheckInMap(IntFeatureData, StringData, "AP_begin_indices",
                          nSize);
   if (retVal) {
     return nSize;
@@ -160,7 +160,7 @@ int LibV2::AP_end_indices(mapStr2intVec& IntFeatureData,
                           mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "AP_end_indices", nSize);
+  retVal = CheckInMap(IntFeatureData, StringData, "AP_end_indices", nSize);
   if (retVal) {
     return nSize;
   }
@@ -210,7 +210,7 @@ int LibV2::AP_rise_indices(mapStr2intVec& IntFeatureData,
                            mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "AP_rise_indices",
+  retVal = CheckInMap(IntFeatureData, StringData, "AP_rise_indices",
                          nSize);
   if (retVal) {
     return nSize;
@@ -256,7 +256,7 @@ int LibV2::AP_fall_indices(mapStr2intVec& IntFeatureData,
                            mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "AP_fall_indices", nSize);
+  retVal = CheckInMap(IntFeatureData, StringData, "AP_fall_indices", nSize);
   if (retVal) {
     return nSize;
   }
@@ -300,7 +300,7 @@ int LibV2::AP_duration(mapStr2intVec& IntFeatureData,
                        mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_duration", nsize);
   if (retval) {
     return nsize;
@@ -341,7 +341,7 @@ int LibV2::AP_duration_half_width(mapStr2intVec& IntFeatureData,
                                   mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_duration_half_width", nsize);
   if (retval) {
     return nsize;
@@ -384,7 +384,7 @@ int LibV2::AP_rise_time(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_rise_time", nsize);
   if (retval) {
     return nsize;
@@ -425,7 +425,7 @@ int LibV2::AP_fall_time(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_fall_time", nsize);
   if (retval) {
     return nsize;
@@ -467,7 +467,7 @@ int LibV2::AP_rise_rate(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_rise_rate", nsize);
   if (retval) {
     return nsize;
@@ -512,7 +512,7 @@ int LibV2::AP_fall_rate(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_fall_rate", nsize);
   if (retval) {
     return nsize;
@@ -558,7 +558,7 @@ int LibV2::fast_AHP(mapStr2intVec& IntFeatureData,
                     mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "fast_AHP", nsize);
+  retval = CheckInMap(DoubleFeatureData, StringData, "fast_AHP", nsize);
   if (retval) {
     return nsize;
   }
@@ -600,7 +600,7 @@ int LibV2::AP_amplitude_change(mapStr2intVec& IntFeatureData,
                                mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_amplitude_change", nsize);
   if (retval) {
     return nsize;
@@ -636,7 +636,7 @@ int LibV2::AP_duration_change(mapStr2intVec& IntFeatureData,
                               mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_duration_change", nsize);
   if (retval) {
     return nsize;
@@ -675,7 +675,7 @@ int LibV2::AP_duration_half_width_change(mapStr2intVec& IntFeatureData,
                                          mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_duration_half_width_change", nsize);
   if (retval) {
     return nsize;
@@ -713,7 +713,7 @@ int LibV2::AP_rise_rate_change(mapStr2intVec& IntFeatureData,
                                mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_rise_rate_change", nsize);
   if (retval) {
     return nsize;
@@ -749,7 +749,7 @@ int LibV2::AP_fall_rate_change(mapStr2intVec& IntFeatureData,
                                mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_fall_rate_change", nsize);
   if (retval) {
     return nsize;
@@ -785,7 +785,7 @@ int LibV2::fast_AHP_change(mapStr2intVec& IntFeatureData,
                            mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "fast_AHP_change", nsize);
   if (retval) {
     return nsize;
@@ -808,7 +808,7 @@ int LibV2::E6(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "E6", nsize);
+  retval = CheckInMap(DoubleFeatureData, StringData, "E6", nsize);
   if (retval) {
     return nsize;
   }
@@ -828,7 +828,7 @@ int LibV2::E7(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "E7", nsize);
+  retval = CheckInMap(DoubleFeatureData, StringData, "E7", nsize);
   if (retval) {
     return nsize;
   }
@@ -849,7 +849,7 @@ int LibV2::BPAPatt2(mapStr2intVec& IntFeatureData,
                     mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "BPAPatt2",
+  retval = CheckInMap(DoubleFeatureData, StringData, "BPAPatt2",
                             nsize);
   if (retval) {
     return nsize;
@@ -893,7 +893,7 @@ int LibV2::BPAPatt3(mapStr2intVec& IntFeatureData,
                     mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "BPAPatt3",
+  retval = CheckInMap(DoubleFeatureData, StringData, "BPAPatt3",
                             nsize);
   if (retval) {
     return nsize;
@@ -938,7 +938,7 @@ int LibV2::E39(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E39", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E39", nsize);
   if (retval) {
     return nsize;
   }
@@ -984,7 +984,7 @@ int LibV2::E39_cod(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E39_cod", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E39_cod", nsize);
   return retval;
 }
 // end of E39_cod
@@ -1000,7 +1000,7 @@ int LibV2::amp_drop_first_second(mapStr2intVec& IntFeatureData,
                                  mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "amp_drop_first_second", nsize);
   if (retval) {
     return nsize;
@@ -1028,7 +1028,7 @@ int LibV2::E2(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "E2", nsize);
+  retval = CheckInMap(DoubleFeatureData, StringData, "E2", nsize);
   if (retval) {
     return nsize;
   }
@@ -1054,7 +1054,7 @@ int LibV2::amp_drop_first_last(mapStr2intVec& IntFeatureData,
                                mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "amp_drop_first_last", nsize);
   if (retval) {
     return nsize;
@@ -1082,7 +1082,7 @@ int LibV2::E3(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "E3", nsize);
+  retval = CheckInMap(DoubleFeatureData, StringData, "E3", nsize);
   if (retval) {
     return nsize;
   }
@@ -1108,7 +1108,7 @@ int LibV2::amp_drop_second_last(mapStr2intVec& IntFeatureData,
                                 mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "amp_drop_second_last", nsize);
   if (retval) {
     return nsize;
@@ -1136,7 +1136,7 @@ int LibV2::E4(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "E4", nsize);
+  retval = CheckInMap(DoubleFeatureData, StringData, "E4", nsize);
   if (retval) {
     return nsize;
   }
@@ -1172,7 +1172,7 @@ int LibV2::max_amp_difference(mapStr2intVec& IntFeatureData,
                               mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "max_amp_difference", nsize);
   if (retval) {
     return nsize;
@@ -1200,7 +1200,7 @@ int LibV2::E5(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "E5", nsize);
+  retval = CheckInMap(DoubleFeatureData, StringData, "E5", nsize);
   if (retval) {
     return nsize;
   }
@@ -1220,7 +1220,7 @@ int LibV2::E8(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "E8", nsize);
+  retval = CheckInMap(DoubleFeatureData, StringData, "E8", nsize);
   if (retval) {
     return nsize;
   }
@@ -1240,7 +1240,7 @@ int LibV2::E9(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "E9", nsize);
+  retval = CheckInMap(DoubleFeatureData, StringData, "E9", nsize);
   if (retval) {
     return nsize;
   }
@@ -1261,7 +1261,7 @@ int LibV2::E10(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E10", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E10", nsize);
   if (retval) {
     return nsize;
   }
@@ -1282,7 +1282,7 @@ int LibV2::E11(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E11", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E11", nsize);
   if (retval) {
     return nsize;
   }
@@ -1303,7 +1303,7 @@ int LibV2::E12(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E12", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E12", nsize);
   if (retval) {
     return nsize;
   }
@@ -1324,7 +1324,7 @@ int LibV2::E13(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E13", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E13", nsize);
   if (retval) {
     return nsize;
   }
@@ -1345,7 +1345,7 @@ int LibV2::E14(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E14", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E14", nsize);
   if (retval) {
     return nsize;
   }
@@ -1367,7 +1367,7 @@ int LibV2::E15(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E15", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E15", nsize);
   if (retval) {
     return nsize;
   }
@@ -1389,7 +1389,7 @@ int LibV2::E16(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E16", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E16", nsize);
   if (retval) {
     return nsize;
   }
@@ -1411,7 +1411,7 @@ int LibV2::E17(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E17", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E17", nsize);
   if (retval) {
     return nsize;
   }
@@ -1433,7 +1433,7 @@ int LibV2::E18(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E18", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E18", nsize);
   if (retval) {
     return nsize;
   }
@@ -1455,7 +1455,7 @@ int LibV2::E19(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E19", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E19", nsize);
   if (retval) {
     return nsize;
   }
@@ -1477,7 +1477,7 @@ int LibV2::E20(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E20", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E20", nsize);
   if (retval) {
     return nsize;
   }
@@ -1499,7 +1499,7 @@ int LibV2::E21(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E21", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E21", nsize);
   if (retval) {
     return nsize;
   }
@@ -1521,7 +1521,7 @@ int LibV2::E22(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E22", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E22", nsize);
   if (retval) {
     return nsize;
   }
@@ -1541,7 +1541,7 @@ int LibV2::E23(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E23", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E23", nsize);
   if (retval) {
     return nsize;
   }
@@ -1561,7 +1561,7 @@ int LibV2::E24(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E24", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E24", nsize);
   if (retval) {
     return nsize;
   }
@@ -1581,7 +1581,7 @@ int LibV2::E25(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E25", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E25", nsize);
   if (retval) {
     return nsize;
   }
@@ -1601,7 +1601,7 @@ int LibV2::E26(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E26", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E26", nsize);
   if (retval) {
     return nsize;
   }
@@ -1621,7 +1621,7 @@ int LibV2::E27(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E27", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E27", nsize);
   if (retval) {
     return nsize;
   }
@@ -1669,7 +1669,7 @@ int LibV2::steady_state_hyper(mapStr2intVec& IntFeatureData,
                               mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "steady_state_hyper",
+  retval = CheckInMap(DoubleFeatureData, StringData, "steady_state_hyper",
                             nsize);
   if (retval) {
     return nsize;
@@ -1698,7 +1698,7 @@ int LibV2::E40(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "E40", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "E40", nsize);
   if (retval) {
     return nsize;
   }

--- a/efel/cppcore/LibV3.cpp
+++ b/efel/cppcore/LibV3.cpp
@@ -34,7 +34,7 @@ int LibV3::interpolate(mapStr2intVec& IntFeatureData,
                        mapStr2doubleVec& DoubleFeatureData,
                        mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "interpolate", nSize);
+  retVal = CheckInMap(IntFeatureData, StringData, "interpolate", nSize);
   if (retVal)
     return nSize;
 
@@ -67,7 +67,7 @@ int LibV3::trace_check(mapStr2intVec& IntFeatureData,
                        mapStr2Str& StringData) {
   int retval;
   int size;
-  retval = CheckInIntmap(IntFeatureData, StringData, "trace_check", size);
+  retval = CheckInMap(IntFeatureData, StringData, "trace_check", size);
   if (retval)
     return size;
 
@@ -140,7 +140,7 @@ int LibV3::peak_indices(mapStr2intVec& IntFeatureData,
   // printf("\n  LibV1  This is inside peak_indices()");
   int retVal, nSize;
   retVal =
-      CheckInIntmap(IntFeatureData, StringData, "peak_indices", nSize);
+      CheckInMap(IntFeatureData, StringData, "peak_indices", nSize);
   if (retVal)
     return nSize;
 
@@ -162,7 +162,7 @@ int LibV3::ISI_values(mapStr2intVec& IntFeatureData,
                       mapStr2Str& StringData) {
   //  printf("\n  LibV1  This is inside ISI_values()");
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "ISI_values",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "ISI_values",
                             nSize);
   if (retVal)
     return nSize;
@@ -205,7 +205,7 @@ int LibV3::ISI_CV(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "ISI_CV", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "ISI_CV", nsize);
   if (retval) {
     return nsize;
   }
@@ -226,7 +226,7 @@ int LibV3::peak_voltage(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   // printf("\n  LibV1  Inside PeakVoltage ... LibV1");
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "peak_voltage", nSize);
   if (retVal)
     return nSize;
@@ -252,7 +252,7 @@ int LibV3::firing_rate(mapStr2intVec& IntFeatureData,
                        mapStr2Str& StringData) {
   // printf("\n  LibV1  This is inside firing_rate()");
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "mean_frequency", nSize);
   if (retVal)
     return nSize;
@@ -288,7 +288,7 @@ int LibV3::peak_time(mapStr2intVec& IntFeatureData,
                      mapStr2Str& StringData) {
   // printf("\n  LibV1  This is inside peak_time()");
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "peak_time", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "peak_time", nSize);
   if (retVal)
     return nSize;
 
@@ -311,7 +311,7 @@ int LibV3::first_spike_time(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "time_to_first_spike", nSize);
   if (retVal)
     return nSize;
@@ -380,7 +380,7 @@ int LibV3::spike_width1(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "spike_half_width", nSize);
   if (retVal)
     return nSize;
@@ -423,7 +423,7 @@ int LibV3::min_AHP_indices(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "min_AHP_indices",
+  retVal = CheckInMap(IntFeatureData, StringData, "min_AHP_indices",
                          nSize);
   if (retVal)
     return nSize;
@@ -474,7 +474,7 @@ int LibV3::min_AHP_values(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "min_AHP_values", nSize);
   if (retVal) return nSize;
   return -1;
@@ -490,7 +490,7 @@ int LibV3::AHP_depth_abs(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "AHP_depth_abs", nSize);
   if (retVal)
     return nSize;
@@ -507,7 +507,7 @@ int LibV3::rest_voltage_value(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "voltage_base", nSize);
   if (retVal)
     return nSize;
@@ -595,7 +595,7 @@ int LibV3::adaptation_index2(mapStr2intVec& IntFeatureData,
                              mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "adaptation_index2", nsize);
   if (retval) {
     return nsize;
@@ -639,7 +639,7 @@ int LibV3::AP_height(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP_height",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP_height",
                             nSize);
   if (retVal)
     return nSize;
@@ -657,7 +657,7 @@ int LibV3::AP_amplitude(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "AP_amplitude", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "AP_amplitude", nSize);
   if (retVal > 0)
     return nSize;
 
@@ -734,7 +734,7 @@ int LibV3::AP_width(mapStr2intVec& IntFeatureData,
                     mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "AP_width",
+  retval = CheckInMap(DoubleFeatureData, StringData, "AP_width",
                             nsize);
   if (retval) {
     return nsize;
@@ -777,7 +777,7 @@ int LibV3::doublet_ISI(mapStr2intVec& IntFeatureData,
                        mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "doublet_ISI", nsize);
   if (retval) {
     return nsize;
@@ -865,7 +865,7 @@ int LibV3::AP_begin_indices(mapStr2intVec& IntFeatureData,
                             mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "AP_begin_indices",
+  retVal = CheckInMap(IntFeatureData, StringData, "AP_begin_indices",
                          nSize);
   if (retVal) {
     return nSize;
@@ -922,7 +922,7 @@ int LibV3::AP_end_indices(mapStr2intVec& IntFeatureData,
                           mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "AP_end_indices",
+  retVal = CheckInMap(IntFeatureData, StringData, "AP_end_indices",
                          nSize);
   if (retVal) {
     return nSize;
@@ -968,7 +968,7 @@ int LibV3::AP_rise_indices(mapStr2intVec& IntFeatureData,
                            mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "AP_rise_indices",
+  retVal = CheckInMap(IntFeatureData, StringData, "AP_rise_indices",
                          nSize);
   if (retVal) {
     return nSize;
@@ -1014,7 +1014,7 @@ int LibV3::AP_fall_indices(mapStr2intVec& IntFeatureData,
                            mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "AP_fall_indices", nSize);
+  retVal = CheckInMap(IntFeatureData, StringData, "AP_fall_indices", nSize);
   if (retVal) {
     return nSize;
   }
@@ -1056,7 +1056,7 @@ int LibV3::AP_duration(mapStr2intVec& IntFeatureData,
                        mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AP_duration", nsize);
   if (retval) {
     return nsize;
@@ -1120,7 +1120,7 @@ int LibV3::depolarized_base(mapStr2intVec& IntFeatureData,
                             mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInIntmap(IntFeatureData, StringData, "depolarized_base",
+  retVal = CheckInMap(IntFeatureData, StringData, "depolarized_base",
                          nSize);
   if (retVal) {
     return nSize;

--- a/efel/cppcore/LibV3.cpp
+++ b/efel/cppcore/LibV3.cpp
@@ -56,9 +56,9 @@ int LibV3::interpolate(mapStr2intVec& IntFeatureData,
 
   LinearInterpolation(InterpStep, T, V, TIntrpol, VIntrpol);
 
-  setDoubleVec(DoubleFeatureData, StringData, "V", VIntrpol);
-  setDoubleVec(DoubleFeatureData, StringData, "T", TIntrpol);
-  setIntVec(IntFeatureData, StringData, "interpolate", intrpolte);
+  setVec(DoubleFeatureData, StringData, "V", VIntrpol);
+  setVec(DoubleFeatureData, StringData, "T", TIntrpol);
+  setVec(IntFeatureData, StringData, "interpolate", intrpolte);
   return retVal;
 }
 
@@ -92,7 +92,7 @@ int LibV3::trace_check(mapStr2intVec& IntFeatureData,
 
   if (sane) {
     tc.push_back(0);
-    setIntVec(IntFeatureData, StringData, "trace_check", tc);
+    setVec(IntFeatureData, StringData, "trace_check", tc);
     return tc.size();
   } else {
     GErrorStr +=
@@ -153,7 +153,7 @@ int LibV3::peak_indices(mapStr2intVec& IntFeatureData,
 
   int retval = __peak_indices(Th[0], v, PeakIndex);
   if (retval >= 0)
-    setIntVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
+    setVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
   return retval;
 }
 
@@ -176,7 +176,7 @@ int LibV3::ISI_values(mapStr2intVec& IntFeatureData,
   for (size_t i = 2; i < pvTime.size(); i++) {
     VecISI.push_back(pvTime[i] - pvTime[i - 1]);
   }
-  setDoubleVec(DoubleFeatureData, StringData, "ISI_values", VecISI);
+  setVec(DoubleFeatureData, StringData, "ISI_values", VecISI);
   return VecISI.size();
 }
 
@@ -216,7 +216,7 @@ int LibV3::ISI_CV(mapStr2intVec& IntFeatureData,
   vector<double> isicv;
   retval = __ISI_CV(isivalues, isicv);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "ISI_CV", isicv);
+    setVec(DoubleFeatureData, StringData, "ISI_CV", isicv);
   }
   return retval;
 }
@@ -243,7 +243,7 @@ int LibV3::peak_voltage(mapStr2intVec& IntFeatureData,
   for (size_t i = 0; i < PeakI.size(); i++) {
     peakV.push_back(V[PeakI[i]]);
   }
-  setDoubleVec(DoubleFeatureData, StringData, "peak_voltage", peakV);
+  setVec(DoubleFeatureData, StringData, "peak_voltage", peakV);
   return peakV.size();
 }
 
@@ -279,7 +279,7 @@ int LibV3::firing_rate(mapStr2intVec& IntFeatureData,
   }
   firing_rate.push_back(nCount * 1000 / (lastAPTime - stimStart[0]));
   firing_rate.push_back(nCount * 1000 / (lastAPTime - stimStart[0]));
-  setDoubleVec(DoubleFeatureData, StringData, "mean_frequency", firing_rate);
+  setVec(DoubleFeatureData, StringData, "mean_frequency", firing_rate);
   return firing_rate.size();
 }
 
@@ -302,7 +302,7 @@ int LibV3::peak_time(mapStr2intVec& IntFeatureData,
   for (size_t i = 0; i < PeakI.size(); i++) {
     pvTime.push_back(T[PeakI[i]]);
   }
-  setDoubleVec(DoubleFeatureData, StringData, "peak_time", pvTime);
+  setVec(DoubleFeatureData, StringData, "peak_time", pvTime);
   return pvTime.size();
 }
 
@@ -328,7 +328,7 @@ int LibV3::first_spike_time(mapStr2intVec& IntFeatureData,
   if (retVal <= 0) return -1;
 
   first_spike.push_back(peaktime[0] - stimstart[0]);
-  setDoubleVec(DoubleFeatureData, StringData, "time_to_first_spike",
+  setVec(DoubleFeatureData, StringData, "time_to_first_spike",
                first_spike);
   return first_spike.size();
 }
@@ -410,7 +410,7 @@ int LibV3::spike_width1(mapStr2intVec& IntFeatureData,
   retVal = __spike_width1(t, V, PeakIndex, minAHPIndex, stim_start[0],
                           spike_width1);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "spike_half_width",
+    setVec(DoubleFeatureData, StringData, "spike_half_width",
                  spike_width1);
   }
   return retVal;
@@ -464,8 +464,8 @@ int LibV3::min_AHP_indices(mapStr2intVec& IntFeatureData,
     min_ahp_indices.push_back(ahpindex);
     min_ahp_values.push_back(v[ahpindex]);
   }
-  setIntVec(IntFeatureData, StringData, "min_AHP_indices", min_ahp_indices);
-  setDoubleVec(DoubleFeatureData, StringData, "min_AHP_values",
+  setVec(IntFeatureData, StringData, "min_AHP_indices", min_ahp_indices);
+  setVec(DoubleFeatureData, StringData, "min_AHP_values",
                min_ahp_values);
   return min_ahp_indices.size();
 }
@@ -499,7 +499,7 @@ int LibV3::AHP_depth_abs(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "min_AHP_values", vAHP);
   if (retVal <= 0) return -1;
 
-  setDoubleVec(DoubleFeatureData, StringData, "AHP_depth_abs", vAHP);
+  setVec(DoubleFeatureData, StringData, "AHP_depth_abs", vAHP);
   return vAHP.size();
 }
 
@@ -538,7 +538,7 @@ int LibV3::rest_voltage_value(mapStr2intVec& IntFeatureData,
     }
   }
   vRest.push_back(vSum / nCount);
-  setDoubleVec(DoubleFeatureData, StringData, "voltage_base", vRest);
+  setVec(DoubleFeatureData, StringData, "voltage_base", vRest);
   return 1;
 }
 
@@ -628,7 +628,7 @@ int LibV3::adaptation_index2(mapStr2intVec& IntFeatureData,
   retval = __adaptation_index2(stimStart[0], stimEnd[0], Offset,
                                peakvoltagetime, adaptationindex2);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "adaptation_index2",
+    setVec(DoubleFeatureData, StringData, "adaptation_index2",
                  adaptationindex2);
   }
   return retval;
@@ -647,7 +647,7 @@ int LibV3::AP_height(mapStr2intVec& IntFeatureData,
   vector<double> vPeak;
   retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_voltage", vPeak);
   if (retVal <= 0) return -1;
-  setDoubleVec(DoubleFeatureData, StringData, "AP_height", vPeak);
+  setVec(DoubleFeatureData, StringData, "AP_height", vPeak);
   return vPeak.size();
 }
 
@@ -678,7 +678,7 @@ int LibV3::AP_amplitude(mapStr2intVec& IntFeatureData,
   for (size_t i = 0; i < apamplitude.size(); i++) {
     apamplitude[i] = peakvoltage[i] - v[apbeginindices[i]];
   }
-  setDoubleVec(DoubleFeatureData, StringData, "AP_amplitude", apamplitude);
+  setVec(DoubleFeatureData, StringData, "AP_amplitude", apamplitude);
   return apamplitude.size();
 }
 
@@ -764,7 +764,7 @@ int LibV3::AP_width(mapStr2intVec& IntFeatureData,
   retval = __AP_width(t, v, stimstart[0], threshold[0], peakindices,
                       minahpindices, apwidth);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_width", apwidth);
+    setVec(DoubleFeatureData, StringData, "AP_width", apwidth);
   }
   return retval;
 }
@@ -789,7 +789,7 @@ int LibV3::doublet_ISI(mapStr2intVec& IntFeatureData,
     return -1;
   }
   vector<double> doubletisi(1, pvt[1] - pvt[0]);
-  setDoubleVec(DoubleFeatureData, StringData, "doublet_ISI", doubletisi);
+  setVec(DoubleFeatureData, StringData, "doublet_ISI", doubletisi);
   return retval;
 }
 // end of doublet_ISI
@@ -888,7 +888,7 @@ int LibV3::AP_begin_indices(mapStr2intVec& IntFeatureData,
   vector<int> apbi;
   retVal = __AP_begin_indices(t, v, stimstart[0], stimend[0], ahpi, apbi);
   if (retVal >= 0) {
-    setIntVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
+    setVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
   }
   return retVal;
 }
@@ -940,7 +940,7 @@ int LibV3::AP_end_indices(mapStr2intVec& IntFeatureData,
   vector<int> apei;
   retVal = __AP_end_indices(t, v, pi, apei);
   if (retVal >= 0) {
-    setIntVec(IntFeatureData, StringData, "AP_end_indices", apei);
+    setVec(IntFeatureData, StringData, "AP_end_indices", apei);
   }
   return retVal;
 }
@@ -986,7 +986,7 @@ int LibV3::AP_rise_indices(mapStr2intVec& IntFeatureData,
   vector<int> apri;
   retVal = __AP_rise_indices(v, apbi, pi, apri);
   if (retVal >= 0) {
-    setIntVec(IntFeatureData, StringData, "AP_rise_indices", apri);
+    setVec(IntFeatureData, StringData, "AP_rise_indices", apri);
   }
   return retVal;
 }
@@ -1034,7 +1034,7 @@ int LibV3::AP_fall_indices(mapStr2intVec& IntFeatureData,
   vector<int> apfi;
   retVal = __AP_fall_indices(v, apbi, apei, pi, apfi);
   if (retVal >= 0) {
-    setIntVec(IntFeatureData, StringData, "AP_fall_indices", apfi);
+    setVec(IntFeatureData, StringData, "AP_fall_indices", apfi);
   }
   return retVal;
 }
@@ -1075,7 +1075,7 @@ int LibV3::AP_duration(mapStr2intVec& IntFeatureData,
   vector<double> apduration;
   retval = __AP_duration(t, apbeginindices, endindices, apduration);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_duration", apduration);
+    setVec(DoubleFeatureData, StringData, "AP_duration", apduration);
   }
   return retval;
 }
@@ -1148,7 +1148,7 @@ int LibV3::depolarized_base(mapStr2intVec& IntFeatureData,
   retVal = __depolarized_base(t, v, stimstart[0], stimend[0], apbi, apendi,
                               dep_base);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "depolarized_base", dep_base);
+    setVec(DoubleFeatureData, StringData, "depolarized_base", dep_base);
   }
   return retVal;
 }

--- a/efel/cppcore/LibV3.cpp
+++ b/efel/cppcore/LibV3.cpp
@@ -41,10 +41,10 @@ int LibV3::interpolate(mapStr2intVec& IntFeatureData,
   vector<double> V, T, VIntrpol, TIntrpol, InterpStepVec;
   vector<int> intrpolte;
   double InterpStep;
-  // getDoubleVec takes care of stimulus suffix
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  // getVec takes care of stimulus suffix
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal <= 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", T);
+  retVal = getVec(DoubleFeatureData, StringData, "T", T);
   if (retVal <= 0) return -1;
   //
   // interp_step is a stimulus independent parameter
@@ -75,11 +75,11 @@ int LibV3::trace_check(mapStr2intVec& IntFeatureData,
   vector<double> stim_start;
   vector<double> stim_end;
   vector<int> tc;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peak_time);
+  retval = getVec(DoubleFeatureData, StringData, "peak_time", peak_time);
   if (retval < 0) return -1;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stim_start);
+  retval = getVec(DoubleFeatureData, StringData, "stim_start", stim_start);
   if (retval < 0) return -1;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stim_end);
+  retval = getVec(DoubleFeatureData, StringData, "stim_end", stim_end);
   if (retval < 0) return -1;
 
   bool sane = true;
@@ -146,7 +146,7 @@ int LibV3::peak_indices(mapStr2intVec& IntFeatureData,
 
   vector<int> PeakIndex;
   vector<double> v, Th;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal <= 0) return -1;
   retVal = getDoubleParam(DoubleFeatureData, "Threshold", Th);
   if (retVal <= 0) return -1;
@@ -168,7 +168,7 @@ int LibV3::ISI_values(mapStr2intVec& IntFeatureData,
     return nSize;
 
   vector<double> VecISI, pvTime;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", pvTime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", pvTime);
   if (retVal < 3) {
     GErrorStr += "\n Three spikes required for calculation of ISI_values.\n";
     return -1;
@@ -210,7 +210,7 @@ int LibV3::ISI_CV(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> isivalues;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "ISI_values",
+  retval = getVec(DoubleFeatureData, StringData, "ISI_values",
                         isivalues);
   if (retval < 2) return -1;
   vector<double> isicv;
@@ -231,13 +231,13 @@ int LibV3::peak_voltage(mapStr2intVec& IntFeatureData,
   if (retVal)
     return nSize;
 
-  // vector<int> PeakI = getIntVec(IntFeatureData, StringData,
+  // vector<int> PeakI = getVec(IntFeatureData, StringData,
   // string("peak_indices"));
   vector<int> PeakI;
   vector<double> V, peakV;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", PeakI);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", PeakI);
   if (retVal <= 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal <= 0) return -1;
 
   for (size_t i = 0; i < PeakI.size(); i++) {
@@ -259,11 +259,11 @@ int LibV3::firing_rate(mapStr2intVec& IntFeatureData,
 
   vector<double> stimStart, stimEnd, peakVTime, firing_rate;
   double lastAPTime = 0.;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peakVTime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", peakVTime);
   if (retVal <= 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal <= 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal <= 0) return -1;
 
   int nCount = 0;
@@ -294,9 +294,9 @@ int LibV3::peak_time(mapStr2intVec& IntFeatureData,
 
   vector<int> PeakI;
   vector<double> T, pvTime;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", PeakI);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", PeakI);
   if (retVal <= 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", T);
+  retVal = getVec(DoubleFeatureData, StringData, "T", T);
   if (retVal <= 0) return -1;
 
   for (size_t i = 0; i < PeakI.size(); i++) {
@@ -319,12 +319,12 @@ int LibV3::first_spike_time(mapStr2intVec& IntFeatureData,
   vector<double> first_spike;
   vector<double> peaktime;
   vector<double> stimstart;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peaktime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", peaktime);
   if (retVal < 1) {
     GErrorStr += "\n One spike required for time_to_first_spike.\n";
     return -1;
   }
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retVal <= 0) return -1;
 
   first_spike.push_back(peaktime[0] - stimstart[0]);
@@ -388,15 +388,15 @@ int LibV3::spike_width1(mapStr2intVec& IntFeatureData,
   vector<int> PeakIndex, minAHPIndex;
   vector<double> V, t, dv1, dv2, spike_width1;
   vector<double> stim_start;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stim_start);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stim_start);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndex);
+  retVal = getVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndex);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
   if (retVal < 0) return -1;
 
   if (PeakIndex.size() <= 1) {
@@ -434,9 +434,9 @@ int LibV3::min_AHP_indices(mapStr2intVec& IntFeatureData,
   vector<double> min_ahp_values;
   vector<double> stim_end;
   vector<double> t;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal <= 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices",
+  retVal = getVec(IntFeatureData, StringData, "peak_indices",
                      peak_indices_plus);
   if (retVal < 1) {
     GErrorStr +=
@@ -444,9 +444,9 @@ int LibV3::min_AHP_indices(mapStr2intVec& IntFeatureData,
         "min_AHP_indices.\n";
     return -1;
   }
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stim_end);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stim_end);
   if (retVal <= 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal <= 0) return -1;
 
   int end_index = distance(
@@ -496,7 +496,7 @@ int LibV3::AHP_depth_abs(mapStr2intVec& IntFeatureData,
     return nSize;
 
   vector<double> vAHP;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "min_AHP_values", vAHP);
+  retVal = getVec(DoubleFeatureData, StringData, "min_AHP_values", vAHP);
   if (retVal <= 0) return -1;
 
   setVec(DoubleFeatureData, StringData, "AHP_depth_abs", vAHP);
@@ -514,11 +514,11 @@ int LibV3::rest_voltage_value(mapStr2intVec& IntFeatureData,
 
   vector<double> v, t, stimStart, vRest;
   double startTime, endTime;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal < 0) return -1;
   startTime = stimStart[0] * .25;  // It is 25% from start (0), so if stimulus
                                    // starts at 100ms then StartTime will be
@@ -601,19 +601,19 @@ int LibV3::adaptation_index2(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> peakvoltagetime;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_time",
+  retval = getVec(DoubleFeatureData, StringData, "peak_time",
                         peakvoltagetime);
   if (retval < 4) {
     GErrorStr += "\n At least 4 spikes needed for adaptation_index2.\n";
     return -1;
   }
   vector<double> stimStart;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retval = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   {
     if (retval < 0) return -1;
   };
   vector<double> stimEnd;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retval = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   {
     if (retval < 0) return -1;
   };
@@ -645,7 +645,7 @@ int LibV3::AP_height(mapStr2intVec& IntFeatureData,
     return nSize;
 
   vector<double> vPeak;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_voltage", vPeak);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_voltage", vPeak);
   if (retVal <= 0) return -1;
   setVec(DoubleFeatureData, StringData, "AP_height", vPeak);
   return vPeak.size();
@@ -664,12 +664,12 @@ int LibV3::AP_amplitude(mapStr2intVec& IntFeatureData,
   vector<double> peakvoltage;
   vector<int> apbeginindices;
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal <= 0) { return -1; }
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_voltage",
+  retVal = getVec(DoubleFeatureData, StringData, "peak_voltage",
                         peakvoltage);
   if (retVal <= 0) { return -1; }
-  retVal = getIntVec(IntFeatureData, StringData, "AP_begin_indices",
+  retVal = getVec(IntFeatureData, StringData, "AP_begin_indices",
                      apbeginindices);
   if (retVal <= 0) { return -1; }
 
@@ -740,25 +740,25 @@ int LibV3::AP_width(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> t;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
   vector<double> v;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retval = getVec(DoubleFeatureData, StringData, "V", v);
   if (retval < 0) return -1;
   vector<double> threshold;
   retval = getDoubleParam(DoubleFeatureData, "Threshold", threshold);
   if (retval < 0) return -1;
   vector<double> stimstart;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retval = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retval < 0) return -1;
   vector<int> peakindices;
-  retval = getIntVec(IntFeatureData, StringData, "peak_indices", peakindices);
+  retval = getVec(IntFeatureData, StringData, "peak_indices", peakindices);
   if (retval <= 0) {
     GErrorStr += "\nNo spike in trace.\n";
     return -1;
   }
   vector<int> minahpindices;
-  retval = getIntVec(IntFeatureData, StringData, "min_AHP_indices", minahpindices);
+  retval = getVec(IntFeatureData, StringData, "min_AHP_indices", minahpindices);
   if (retval < 0) return -1;
   vector<double> apwidth;
   retval = __AP_width(t, v, stimstart[0], threshold[0], peakindices,
@@ -783,7 +783,7 @@ int LibV3::doublet_ISI(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> pvt;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_time", pvt);
+  retval = getVec(DoubleFeatureData, StringData, "peak_time", pvt);
   if (retval < 2) {
     GErrorStr += "\nNeed at least two spikes for doublet_ISI.\n";
     return -1;
@@ -871,19 +871,19 @@ int LibV3::AP_begin_indices(mapStr2intVec& IntFeatureData,
     return nSize;
   }
   vector<double> t;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
   vector<double> stimstart;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retVal < 0) return -1;
   vector<double> stimend;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimend);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimend);
   if (retVal < 0) return -1;
   vector<int> ahpi;
-  retVal = getIntVec(IntFeatureData, StringData, "min_AHP_indices", ahpi);
+  retVal = getVec(IntFeatureData, StringData, "min_AHP_indices", ahpi);
   if (retVal < 0) return -1;
   vector<int> apbi;
   retVal = __AP_begin_indices(t, v, stimstart[0], stimend[0], ahpi, apbi);
@@ -929,13 +929,13 @@ int LibV3::AP_end_indices(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> t;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
   vector<int> pi;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", pi);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", pi);
   if (retVal < 0) return -1;
   vector<int> apei;
   retVal = __AP_end_indices(t, v, pi, apei);
@@ -975,13 +975,13 @@ int LibV3::AP_rise_indices(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
   vector<int> apbi;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
+  retVal = getVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
   if (retVal < 0) return -1;
   vector<int> pi;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", pi);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", pi);
   if (retVal < 0) return -1;
   vector<int> apri;
   retVal = __AP_rise_indices(v, apbi, pi, apri);
@@ -1020,16 +1020,16 @@ int LibV3::AP_fall_indices(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
   vector<int> apbi;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
+  retVal = getVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
   if (retVal < 0) return -1;
   vector<int> apei;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_end_indices", apei);
+  retVal = getVec(IntFeatureData, StringData, "AP_end_indices", apei);
   if (retVal < 0) return -1;
   vector<int> pi;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", pi);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", pi);
   if (retVal < 0) return -1;
   vector<int> apfi;
   retVal = __AP_fall_indices(v, apbi, apei, pi, apfi);
@@ -1062,14 +1062,14 @@ int LibV3::AP_duration(mapStr2intVec& IntFeatureData,
     return nsize;
   }
   vector<double> t;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
   vector<int> apbeginindices;
-  retval = getIntVec(IntFeatureData, StringData, "AP_begin_indices",
+  retval = getVec(IntFeatureData, StringData, "AP_begin_indices",
                      apbeginindices);
   if (retval < 0) return -1;
   vector<int> endindices;
-  retval = getIntVec(IntFeatureData, StringData, "AP_end_indices",
+  retval = getVec(IntFeatureData, StringData, "AP_end_indices",
                      endindices);
   if (retval < 0) return -1;
   vector<double> apduration;
@@ -1126,22 +1126,22 @@ int LibV3::depolarized_base(mapStr2intVec& IntFeatureData,
     return nSize;
   }
   vector<double> t;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
   vector<double> stimstart;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retVal < 0) return -1;
   vector<double> stimend;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimend);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimend);
   if (retVal < 0) return -1;
   vector<int> apendi;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_end_indices", apendi);
+  retVal = getVec(IntFeatureData, StringData, "AP_end_indices", apendi);
   if (retVal < 0) return -1;
   vector<int> apbi;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
+  retVal = getVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
   if (retVal < 0) return -1;
 
   vector<double> dep_base;

--- a/efel/cppcore/LibV4.cpp
+++ b/efel/cppcore/LibV4.cpp
@@ -68,7 +68,7 @@ int LibV4::peak_indices(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
   int size;
-  if (CheckInIntmap(IntFeatureData, StringData, "peak_indices", size)) {
+  if (CheckInMap(IntFeatureData, StringData, "peak_indices", size)) {
     return size;
   }
 

--- a/efel/cppcore/LibV4.cpp
+++ b/efel/cppcore/LibV4.cpp
@@ -76,7 +76,7 @@ int LibV4::peak_indices(mapStr2intVec& IntFeatureData,
   vector<double> v;
   vector<double> min_spike_height;
   vector<double> threshold;
-  if (getDoubleVec(DoubleFeatureData, StringData, "V", v) <= 0) {
+  if (getVec(DoubleFeatureData, StringData, "V", v) <= 0) {
     return -1;
   }
   if (getDoubleParam(DoubleFeatureData, "min_spike_height", min_spike_height) <=

--- a/efel/cppcore/LibV4.cpp
+++ b/efel/cppcore/LibV4.cpp
@@ -89,7 +89,7 @@ int LibV4::peak_indices(mapStr2intVec& IntFeatureData,
 
   int retval = __peak_indices(v, min_spike_height[0], threshold[0], peakindices);
   if (retval >= 0) {
-    setIntVec(IntFeatureData, StringData, "peak_indices", peakindices);
+    setVec(IntFeatureData, StringData, "peak_indices", peakindices);
     return peakindices.size();
   }
 

--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -89,7 +89,7 @@ int LibV5::ISI_log_slope(mapStr2intVec& IntFeatureData,
   bool semilog = false;
   int retval = __ISI_log_slope(isivalues, slope, false, 0, 0, semilog);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "ISI_log_slope", slope);
+    setVec(DoubleFeatureData, StringData, "ISI_log_slope", slope);
     return slope.size();
   } else {
     return retval;
@@ -113,7 +113,7 @@ int LibV5::ISI_semilog_slope(mapStr2intVec& IntFeatureData,
   bool semilog = true;
   int retval = __ISI_log_slope(isivalues, slope, false, 0, 0, semilog);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "ISI_semilog_slope", slope);
+    setVec(DoubleFeatureData, StringData, "ISI_semilog_slope", slope);
     return slope.size();
   } else {
     return retval;
@@ -155,7 +155,7 @@ int LibV5::ISI_log_slope_skip(mapStr2intVec& IntFeatureData,
   retVal = __ISI_log_slope(isivalues, slope, true, spikeSkipf[0], maxnSpike[0],
                            semilog);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "ISI_log_slope_skip", slope);
+    setVec(DoubleFeatureData, StringData, "ISI_log_slope_skip", slope);
     return slope.size();
   } else {
     return retVal;
@@ -183,7 +183,7 @@ int LibV5::time_to_second_spike(mapStr2intVec& IntFeatureData,
   if (retVal <= 0) return -1;
 
   second_spike.push_back(peaktime[1] - stimstart[0]);
-  setDoubleVec(DoubleFeatureData, StringData, "time_to_second_spike",
+  setVec(DoubleFeatureData, StringData, "time_to_second_spike",
                second_spike);
   return second_spike.size();
 }
@@ -207,14 +207,14 @@ int LibV5::time_to_last_spike(mapStr2intVec& IntFeatureData,
     return -1;
   } else if (retVal == 0) {
     last_spike.push_back(0.0);
-    setDoubleVec(DoubleFeatureData, StringData, "time_to_last_spike",
+    setVec(DoubleFeatureData, StringData, "time_to_last_spike",
                  last_spike);
   } else {
     retVal =
         getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
     if (retVal <= 0) return -1;
     last_spike.push_back(peaktime[peaktime.size() - 1] - stimstart[0]);
-    setDoubleVec(DoubleFeatureData, StringData, "time_to_last_spike",
+    setVec(DoubleFeatureData, StringData, "time_to_last_spike",
                  last_spike);
   }
   return 1;
@@ -240,7 +240,7 @@ int LibV5::inv_first_ISI(mapStr2intVec& IntFeatureData,
     inv_first_ISI = 1000.0 / all_isi_values_vec[0];
   }
   inv_first_ISI_vec.push_back(inv_first_ISI);
-  setDoubleVec(DoubleFeatureData, StringData, "inv_first_ISI",
+  setVec(DoubleFeatureData, StringData, "inv_first_ISI",
                inv_first_ISI_vec);
   return 1;
 }
@@ -265,7 +265,7 @@ int LibV5::inv_second_ISI(mapStr2intVec& IntFeatureData,
     inv_second_ISI = 1000.0 / all_isi_values_vec[1];
   }
   inv_second_ISI_vec.push_back(inv_second_ISI);
-  setDoubleVec(DoubleFeatureData, StringData, "inv_second_ISI",
+  setVec(DoubleFeatureData, StringData, "inv_second_ISI",
                inv_second_ISI_vec);
   return 1;
 }
@@ -290,7 +290,7 @@ int LibV5::inv_third_ISI(mapStr2intVec& IntFeatureData,
     inv_third_ISI = 1000.0 / all_isi_values_vec[2];
   }
   inv_third_ISI_vec.push_back(inv_third_ISI);
-  setDoubleVec(DoubleFeatureData, StringData, "inv_third_ISI",
+  setVec(DoubleFeatureData, StringData, "inv_third_ISI",
                inv_third_ISI_vec);
   return 1;
 }
@@ -315,7 +315,7 @@ int LibV5::inv_fourth_ISI(mapStr2intVec& IntFeatureData,
     inv_fourth_ISI = 1000.0 / all_isi_values_vec[3];
   }
   inv_fourth_ISI_vec.push_back(inv_fourth_ISI);
-  setDoubleVec(DoubleFeatureData, StringData, "inv_fourth_ISI",
+  setVec(DoubleFeatureData, StringData, "inv_fourth_ISI",
                inv_fourth_ISI_vec);
   return 1;
 }
@@ -340,7 +340,7 @@ int LibV5::inv_fifth_ISI(mapStr2intVec& IntFeatureData,
     inv_fifth_ISI = 1000.0 / all_isi_values_vec[4];
   }
   inv_fifth_ISI_vec.push_back(inv_fifth_ISI);
-  setDoubleVec(DoubleFeatureData, StringData, "inv_fifth_ISI",
+  setVec(DoubleFeatureData, StringData, "inv_fifth_ISI",
                inv_fifth_ISI_vec);
   return 1;
 }
@@ -364,7 +364,7 @@ int LibV5::inv_last_ISI(mapStr2intVec& IntFeatureData,
     inv_last_ISI = 1000.0 / all_isi_values_vec[all_isi_values_vec.size() - 1];
   }
   inv_last_ISI_vec.push_back(inv_last_ISI);
-  setDoubleVec(DoubleFeatureData, StringData, "inv_last_ISI", inv_last_ISI_vec);
+  setVec(DoubleFeatureData, StringData, "inv_last_ISI", inv_last_ISI_vec);
   return 1;
 }
 
@@ -388,7 +388,7 @@ int LibV5::inv_time_to_first_spike(mapStr2intVec& IntFeatureData,
     inv_time_to_first_spike = 1000.0 / time_to_first_spike_vec[0];
   }
   inv_time_to_first_spike_vec.push_back(inv_time_to_first_spike);
-  setDoubleVec(DoubleFeatureData, StringData, "inv_time_to_first_spike",
+  setVec(DoubleFeatureData, StringData, "inv_time_to_first_spike",
                inv_time_to_first_spike_vec);
   return 1;
 }
@@ -497,8 +497,8 @@ int LibV5::min_AHP_indices(mapStr2intVec& IntFeatureData,
                         strict_stiminterval, min_ahp_indices, min_ahp_values);
 
   if (retVal > 0) {
-    setIntVec(IntFeatureData, StringData, "min_AHP_indices", min_ahp_indices);
-    setDoubleVec(DoubleFeatureData, StringData, "min_AHP_values",
+    setVec(IntFeatureData, StringData, "min_AHP_indices", min_ahp_indices);
+    setVec(DoubleFeatureData, StringData, "min_AHP_values",
                  min_ahp_values);
   }
   return retVal;
@@ -527,7 +527,7 @@ int LibV5::AHP_depth_abs(mapStr2intVec& IntFeatureData,
   vector<double> vAHP;
   retVal = getDoubleVec(DoubleFeatureData, StringData, "min_AHP_values", vAHP);
   if (retVal < 0) return -1;
-  setDoubleVec(DoubleFeatureData, StringData, "AHP_depth_abs", vAHP);
+  setVec(DoubleFeatureData, StringData, "AHP_depth_abs", vAHP);
   return vAHP.size();
 }
 
@@ -602,7 +602,7 @@ int LibV5::spike_width1(mapStr2intVec& IntFeatureData,
   // if(PeakIndex.size()<1) {GErrorStr = GErrorStr + "\nError: One spike is
   // needed for spikewidth calculation.\n"; return -1;}
   if (PeakIndex.size() == 0 || minAHPIndex.size() == 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "spike_half_width",
+    setVec(DoubleFeatureData, StringData, "spike_half_width",
                  spike_width1);
     return 0;
   }
@@ -611,7 +611,7 @@ int LibV5::spike_width1(mapStr2intVec& IntFeatureData,
   retVal =
       __spike_width1(t, V, PeakIndex, minAHPIndex, stim_start[0], spike_width1);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "spike_half_width",
+    setVec(DoubleFeatureData, StringData, "spike_half_width",
                  spike_width1);
   }
   return retVal;
@@ -747,7 +747,7 @@ int LibV5::AP_begin_indices(mapStr2intVec& IntFeatureData,
 
   // Save feature value
   if (retVal >= 0) {
-    setIntVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
+    setVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
   }
   return retVal;
 }
@@ -781,7 +781,7 @@ int LibV5::irregularity_index(mapStr2intVec& IntFeatureData,
 
   retVal = __irregularity_index(isiValues, irregularity_index);
   if (retVal >= 0)
-    setDoubleVec(DoubleFeatureData, StringData, "irregularity_index",
+    setVec(DoubleFeatureData, StringData, "irregularity_index",
                  irregularity_index);
   return retVal;
 }
@@ -837,7 +837,7 @@ int LibV5::number_initial_spikes(mapStr2intVec& IntFeatureData,
   retVal = __number_initial_spikes(peak_times, stimstart[0], stimend[0],
                                    initial_perc[0], number_initial_spikes);
   if (retVal >= 0)
-    setIntVec(IntFeatureData, StringData, "number_initial_spikes",
+    setVec(IntFeatureData, StringData, "number_initial_spikes",
               number_initial_spikes);
   return retVal;
 }
@@ -854,13 +854,13 @@ int LibV5::AP1_amp(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_amplitude",
                         AP_amplitudes);
   if (retVal < 1) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP1_amp", AP1_amp);
+    setVec(DoubleFeatureData, StringData, "AP1_amp", AP1_amp);
     return 0;
   } else {
     AP1_amp.push_back(AP_amplitudes[0]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "AP1_amp", AP1_amp);
+  setVec(DoubleFeatureData, StringData, "AP1_amp", AP1_amp);
   return 1;
 }
 
@@ -877,13 +877,13 @@ int LibV5::APlast_amp(mapStr2intVec& IntFeatureData,
   AP_amplitude_size = getDoubleVec(DoubleFeatureData, StringData,
                                    "AP_amplitude", AP_amplitudes);
   if (AP_amplitude_size < 1) {
-    setDoubleVec(DoubleFeatureData, StringData, "APlast_amp", APlast_amp);
+    setVec(DoubleFeatureData, StringData, "APlast_amp", APlast_amp);
     return 0;
   } else {
     APlast_amp.push_back(AP_amplitudes[AP_amplitude_size - 1]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "APlast_amp", APlast_amp);
+  setVec(DoubleFeatureData, StringData, "APlast_amp", APlast_amp);
   return 1;
 }
 
@@ -899,13 +899,13 @@ int LibV5::AP1_peak(mapStr2intVec& IntFeatureData,
   retVal =
       getDoubleVec(DoubleFeatureData, StringData, "peak_voltage", peak_voltage);
   if (retVal < 1) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP1_peak", AP1_peak);
+    setVec(DoubleFeatureData, StringData, "AP1_peak", AP1_peak);
     return 0;
   } else {
     AP1_peak.push_back(peak_voltage[0]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "AP1_peak", AP1_peak);
+  setVec(DoubleFeatureData, StringData, "AP1_peak", AP1_peak);
   return 1;
 }
 
@@ -921,13 +921,13 @@ int LibV5::AP2_amp(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_amplitude",
                         AP_amplitudes);
   if (retVal < 2) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP2_amp", AP2_amp);
+    setVec(DoubleFeatureData, StringData, "AP2_amp", AP2_amp);
     return 0;
   } else {
     AP2_amp.push_back(AP_amplitudes[1]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "AP2_amp", AP2_amp);
+  setVec(DoubleFeatureData, StringData, "AP2_amp", AP2_amp);
 
   return 1;
 }
@@ -944,13 +944,13 @@ int LibV5::AP2_peak(mapStr2intVec& IntFeatureData,
   retVal =
       getDoubleVec(DoubleFeatureData, StringData, "peak_voltage", peak_voltage);
   if (retVal < 2) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP2_peak", AP2_peak);
+    setVec(DoubleFeatureData, StringData, "AP2_peak", AP2_peak);
     return 0;
   } else {
     AP2_peak.push_back(peak_voltage[1]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "AP2_peak", AP2_peak);
+  setVec(DoubleFeatureData, StringData, "AP2_peak", AP2_peak);
   return 1;
 }
 
@@ -967,13 +967,13 @@ int LibV5::AP2_AP1_diff(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_amplitude",
                         AP_amplitudes);
   if (retVal < 2) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP2_AP1_diff", AP2_AP1_diff);
+    setVec(DoubleFeatureData, StringData, "AP2_AP1_diff", AP2_AP1_diff);
     return 0;
   } else {
     AP2_AP1_diff.push_back(AP_amplitudes[1] - AP_amplitudes[0]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "AP2_AP1_diff", AP2_AP1_diff);
+  setVec(DoubleFeatureData, StringData, "AP2_AP1_diff", AP2_AP1_diff);
 
   return 1;
 }
@@ -990,14 +990,14 @@ int LibV5::AP2_AP1_peak_diff(mapStr2intVec& IntFeatureData,
   retVal =
       getDoubleVec(DoubleFeatureData, StringData, "peak_voltage", peak_voltage);
   if (retVal < 2) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP2_AP1_peak_diff",
+    setVec(DoubleFeatureData, StringData, "AP2_AP1_peak_diff",
                  AP2_AP1_peak_diff);
     return 0;
   } else {
     AP2_AP1_peak_diff.push_back(peak_voltage[1] - peak_voltage[0]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "AP2_AP1_peak_diff",
+  setVec(DoubleFeatureData, StringData, "AP2_AP1_peak_diff",
                AP2_AP1_peak_diff);
 
   return 1;
@@ -1014,13 +1014,13 @@ int LibV5::AP1_width(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "spike_half_width",
                         spike_half_width);
   if (retVal < 1) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP1_width", AP1_width);
+    setVec(DoubleFeatureData, StringData, "AP1_width", AP1_width);
     return 0;
   } else {
     AP1_width.push_back(spike_half_width[0]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "AP1_width", AP1_width);
+  setVec(DoubleFeatureData, StringData, "AP1_width", AP1_width);
 
   return 1;
 }
@@ -1037,13 +1037,13 @@ int LibV5::AP2_width(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "spike_half_width",
                         spike_half_width);
   if (retVal < 2) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP2_width", AP2_width);
+    setVec(DoubleFeatureData, StringData, "AP2_width", AP2_width);
     return 0;
   } else {
     AP2_width.push_back(spike_half_width[1]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "AP2_width", AP2_width);
+  setVec(DoubleFeatureData, StringData, "AP2_width", AP2_width);
 
   return 1;
 }
@@ -1069,7 +1069,7 @@ int LibV5::APlast_width(mapStr2intVec& IntFeatureData,
     APlast_width.push_back(spike_half_width[spike_half_width_size - 1]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "APlast_width", APlast_width);
+  setVec(DoubleFeatureData, StringData, "APlast_width", APlast_width);
   return 1;
 }
 
@@ -1112,7 +1112,7 @@ int LibV5::AHP_time_from_peak(mapStr2intVec& IntFeatureData,
   vector<double> ahpTimeFromPeak;
   retval = __AHP_time_from_peak(T, peakIndices, minAHPIndices, ahpTimeFromPeak);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AHP_time_from_peak",
+    setVec(DoubleFeatureData, StringData, "AHP_time_from_peak",
                  ahpTimeFromPeak);
   }
   return retval;
@@ -1158,7 +1158,7 @@ int LibV5::AHP_depth_from_peak(mapStr2intVec& IntFeatureData,
   retval =
       __AHP_depth_from_peak(V, peakIndices, minAHPIndices, ahpDepthFromPeak);
   if (retval >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AHP_depth_from_peak",
+    setVec(DoubleFeatureData, StringData, "AHP_depth_from_peak",
                  ahpDepthFromPeak);
   }
   return retval;
@@ -1177,14 +1177,14 @@ int LibV5::AHP1_depth_from_peak(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "AHP_depth_from_peak",
                         ahpDepthFromPeak);
   if (retVal < 1) {
-    setDoubleVec(DoubleFeatureData, StringData, "AHP1_depth_from_peak",
+    setVec(DoubleFeatureData, StringData, "AHP1_depth_from_peak",
                  ahp1DepthFromPeak);
     return 0;
   } else {
     ahp1DepthFromPeak.push_back(ahpDepthFromPeak[0]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "AHP1_depth_from_peak",
+  setVec(DoubleFeatureData, StringData, "AHP1_depth_from_peak",
                ahp1DepthFromPeak);
 
   return 1;
@@ -1203,14 +1203,14 @@ int LibV5::AHP2_depth_from_peak(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "AHP_depth_from_peak",
                         ahpDepthFromPeak);
   if (retVal < 2) {
-    setDoubleVec(DoubleFeatureData, StringData, "AHP2_depth_from_peak",
+    setVec(DoubleFeatureData, StringData, "AHP2_depth_from_peak",
                  ahp2DepthFromPeak);
     return 0;
   } else {
     ahp2DepthFromPeak.push_back(ahpDepthFromPeak[1]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "AHP2_depth_from_peak",
+  setVec(DoubleFeatureData, StringData, "AHP2_depth_from_peak",
                ahp2DepthFromPeak);
 
   return 1;
@@ -1277,7 +1277,7 @@ int LibV5::AP_begin_width(mapStr2intVec& IntFeatureData,
   retVal =
       __AP_begin_width(t, V, AP_begin_indices, minAHPIndex, AP_begin_width);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_begin_width",
+    setVec(DoubleFeatureData, StringData, "AP_begin_width",
                  AP_begin_width);
   }
   return retVal;
@@ -1312,7 +1312,7 @@ int LibV5::AP_begin_time(mapStr2intVec& IntFeatureData,
 
   retVal = __AP_begin_time(t, V, AP_begin_indices, AP_begin_time);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_begin_time", AP_begin_time);
+    setVec(DoubleFeatureData, StringData, "AP_begin_time", AP_begin_time);
   }
   return retVal;
 }
@@ -1346,7 +1346,7 @@ int LibV5::AP_begin_voltage(mapStr2intVec& IntFeatureData,
 
   retVal = __AP_begin_voltage(t, V, AP_begin_indices, AP_begin_voltage);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_begin_voltage",
+    setVec(DoubleFeatureData, StringData, "AP_begin_voltage",
                  AP_begin_voltage);
   }
   return retVal;
@@ -1364,12 +1364,12 @@ int LibV5::AP1_begin_voltage(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_begin_voltage",
                         AP_begin_voltage);
   if (retVal < 1) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP1_begin_voltage",
+    setVec(DoubleFeatureData, StringData, "AP1_begin_voltage",
                  AP1_begin_voltage);
     return 0;
   } else {
     AP1_begin_voltage.push_back(AP_begin_voltage[0]);
-    setDoubleVec(DoubleFeatureData, StringData, "AP1_begin_voltage",
+    setVec(DoubleFeatureData, StringData, "AP1_begin_voltage",
                  AP1_begin_voltage);
     return 1;
   }
@@ -1387,12 +1387,12 @@ int LibV5::AP2_begin_voltage(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_begin_voltage",
                         AP_begin_voltage);
   if (retVal < 2) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP2_begin_voltage",
+    setVec(DoubleFeatureData, StringData, "AP2_begin_voltage",
                  AP2_begin_voltage);
     return 0;
   } else {
     AP2_begin_voltage.push_back(AP_begin_voltage[1]);
-    setDoubleVec(DoubleFeatureData, StringData, "AP2_begin_voltage",
+    setVec(DoubleFeatureData, StringData, "AP2_begin_voltage",
                  AP2_begin_voltage);
     return 1;
   }
@@ -1410,12 +1410,12 @@ int LibV5::AP1_begin_width(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_begin_width",
                         AP_begin_width);
   if (retVal < 1) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP1_begin_width",
+    setVec(DoubleFeatureData, StringData, "AP1_begin_width",
                  AP1_begin_width);
     return 0;
   } else {
     AP1_begin_width.push_back(AP_begin_width[0]);
-    setDoubleVec(DoubleFeatureData, StringData, "AP1_begin_width",
+    setVec(DoubleFeatureData, StringData, "AP1_begin_width",
                  AP1_begin_width);
     return 1;
   }
@@ -1433,12 +1433,12 @@ int LibV5::AP2_begin_width(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_begin_width",
                         AP_begin_width);
   if (retVal < 2) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP2_begin_width",
+    setVec(DoubleFeatureData, StringData, "AP2_begin_width",
                  AP2_begin_width);
     return 0;
   } else {
     AP2_begin_width.push_back(AP_begin_width[1]);
-    setDoubleVec(DoubleFeatureData, StringData, "AP2_begin_width",
+    setVec(DoubleFeatureData, StringData, "AP2_begin_width",
                  AP2_begin_width);
     return 1;
   }
@@ -1457,14 +1457,14 @@ int LibV5::AP2_AP1_begin_width_diff(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_begin_width",
                         AP_begin_widths);
   if (retVal < 2) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP2_AP1_begin_width_diff",
+    setVec(DoubleFeatureData, StringData, "AP2_AP1_begin_width_diff",
                  AP2_AP1_begin_width_diff);
     return 0;
   } else {
     AP2_AP1_begin_width_diff.push_back(AP_begin_widths[1] - AP_begin_widths[0]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "AP2_AP1_begin_width_diff",
+  setVec(DoubleFeatureData, StringData, "AP2_AP1_begin_width_diff",
                AP2_AP1_begin_width_diff);
 
   return 1;
@@ -1531,7 +1531,7 @@ int LibV5::voltage_deflection_begin(mapStr2intVec& IntFeatureData,
   vector<double> vd;
   retVal = __voltage_deflection_begin(v, t, stimStart[0], stimEnd[0], vd);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "voltage_deflection_begin", vd);
+    setVec(DoubleFeatureData, StringData, "voltage_deflection_begin", vd);
   }
   return retVal;
 }
@@ -1569,7 +1569,7 @@ int LibV5::is_not_stuck(mapStr2intVec& IntFeatureData,
   vector<int> tc;
   if (!stuck) {
     tc.push_back(1);
-    setIntVec(IntFeatureData, StringData, "is_not_stuck", tc);
+    setVec(IntFeatureData, StringData, "is_not_stuck", tc);
     return tc.size();
   } else {
     return -1;
@@ -1609,7 +1609,7 @@ int LibV5::voltage_after_stim(mapStr2intVec& IntFeatureData,
   }
   if (nCount == 0) return -1;
   vRest.push_back(vSum / nCount);
-  setDoubleVec(DoubleFeatureData, StringData, "voltage_after_stim", vRest);
+  setVec(DoubleFeatureData, StringData, "voltage_after_stim", vRest);
   return 1;
 }
 
@@ -1646,7 +1646,7 @@ int LibV5::mean_AP_amplitude(mapStr2intVec& IntFeatureData,
   mean_amp /= AP_amplitude.size();
   mean_AP_amplitude.push_back(mean_amp);
 
-  setDoubleVec(DoubleFeatureData, StringData, "mean_AP_amplitude",
+  setVec(DoubleFeatureData, StringData, "mean_AP_amplitude",
                mean_AP_amplitude);
 
   return mean_AP_amplitude.size();
@@ -1687,7 +1687,7 @@ int LibV5::BPAPHeightLoc1(mapStr2intVec& IntFeatureData,
     // vb_dend[0], peakvoltage[0] - vb_dend[0]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "BPAPHeightLoc1", bpapheight);
+  setVec(DoubleFeatureData, StringData, "BPAPHeightLoc1", bpapheight);
   return bpapheight.size();
 }
 // end of BPAPHeightLoc1
@@ -1725,7 +1725,7 @@ int LibV5::BPAPAmplitudeLoc1(mapStr2intVec& IntFeatureData,
     bpapamplitude.push_back(peakvoltage[i] - ap_begin_voltage_dend[i]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "BPAPAmplitudeLoc1",
+  setVec(DoubleFeatureData, StringData, "BPAPAmplitudeLoc1",
                bpapamplitude);
   return bpapamplitude.size();
 }
@@ -1764,7 +1764,7 @@ int LibV5::BPAPAmplitudeLoc2(mapStr2intVec& IntFeatureData,
     bpapamplitude.push_back(peakvoltage[i] - ap_begin_voltage_dend[i]);
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "BPAPAmplitudeLoc2",
+  setVec(DoubleFeatureData, StringData, "BPAPAmplitudeLoc2",
                bpapamplitude);
   return bpapamplitude.size();
 }
@@ -1804,7 +1804,7 @@ int LibV5::BPAPHeightLoc2(mapStr2intVec& IntFeatureData,
     // printf("peak voltage: %f, voltage base: %f, height: %f", peakvoltage[i],
     // vb_dend[0], peakvoltage[0] - vb_dend[0]);
   }
-  setDoubleVec(DoubleFeatureData, StringData, "BPAPHeightLoc2", bpapheight);
+  setVec(DoubleFeatureData, StringData, "BPAPHeightLoc2", bpapheight);
   return bpapheight.size();
 }
 // end of BPAPHeightLoc2
@@ -1860,7 +1860,7 @@ int LibV5::check_AISInitiation(mapStr2intVec& IntFeatureData,
   }
   vector<double> returnvalues;
   returnvalues.push_back(1);
-  setDoubleVec(DoubleFeatureData, StringData, "check_AISInitiation",
+  setVec(DoubleFeatureData, StringData, "check_AISInitiation",
                returnvalues);
   return returnvalues.size();
 }
@@ -1940,7 +1940,7 @@ int LibV5::AP_phaseslope(mapStr2intVec& IntFeatureData,
   retVal = __AP_phaseslope(v, t, stimStart[0], stimEnd[0], ap_phaseslopes, apbi,
                            range_param[0]);
   if (retVal >= 0) {
-    setDoubleVec(DoubleFeatureData, StringData, "AP_phaseslope",
+    setVec(DoubleFeatureData, StringData, "AP_phaseslope",
                  ap_phaseslopes);
   }
   return retVal;
@@ -1961,7 +1961,7 @@ int LibV5::AP_phaseslope_AIS(mapStr2intVec& IntFeatureData,
   retVal = getDoubleVec(DoubleFeatureData, StringData,
                         "AP_phaseslope;location_AIS", ap_phaseslopes);
   if (retVal < 0) return -1;
-  setDoubleVec(DoubleFeatureData, StringData, "AP_phaseslope_AIS",
+  setVec(DoubleFeatureData, StringData, "AP_phaseslope_AIS",
                ap_phaseslopes);
   return retVal;
 }
@@ -1986,7 +1986,7 @@ int LibV5::BAC_width(mapStr2intVec& IntFeatureData,
         "\n More than one spike found a location_epsp for BAC_width.\n";
     return -1;
   }
-  setDoubleVec(DoubleFeatureData, StringData, "BAC_width", ap_width);
+  setVec(DoubleFeatureData, StringData, "BAC_width", ap_width);
 
   return retVal;
 }
@@ -2005,7 +2005,7 @@ int LibV5::BAC_maximum_voltage(mapStr2intVec& IntFeatureData,
                         "maximum_voltage;location_epsp", ap_phaseslopes);
   if (retVal != 1) return -1;
 
-  setDoubleVec(DoubleFeatureData, StringData, "BAC_maximum_voltage",
+  setVec(DoubleFeatureData, StringData, "BAC_maximum_voltage",
                ap_phaseslopes);
   return retVal;
 }
@@ -2027,7 +2027,7 @@ int LibV5::all_ISI_values(mapStr2intVec& IntFeatureData,
   for (size_t i = 1; i < pvTime.size(); i++) {
     VecISI.push_back(pvTime[i] - pvTime[i - 1]);
   }
-  setDoubleVec(DoubleFeatureData, StringData, "all_ISI_values", VecISI);
+  setVec(DoubleFeatureData, StringData, "all_ISI_values", VecISI);
   return VecISI.size();
 }
 
@@ -2065,7 +2065,7 @@ int LibV5::AP_amplitude_from_voltagebase(mapStr2intVec& IntFeatureData,
   for (size_t i = 0; i < apamplitude.size(); i++) {
     apamplitude[i] = peakvoltage[i] - voltage_base;
   }
-  setDoubleVec(DoubleFeatureData, StringData, "AP_amplitude_from_voltagebase",
+  setVec(DoubleFeatureData, StringData, "AP_amplitude_from_voltagebase",
                apamplitude);
   return apamplitude.size();
 }
@@ -2088,7 +2088,7 @@ int LibV5::min_voltage_between_spikes(mapStr2intVec& IntFeatureData,
         "Error calculating peak_indices for min_voltage_between_spikes";
     return -1;
   } else if (retVal < 2) {
-    setDoubleVec(DoubleFeatureData, StringData, "min_voltage_between_spikes",
+    setVec(DoubleFeatureData, StringData, "min_voltage_between_spikes",
                  min_voltage_between_spikes);
     return 0;
   }
@@ -2103,7 +2103,7 @@ int LibV5::min_voltage_between_spikes(mapStr2intVec& IntFeatureData,
     min_voltage_between_spikes.push_back(*min_element(
         v.begin() + peak_indices[i], v.begin() + peak_indices[i + 1]));
   }
-  setDoubleVec(DoubleFeatureData, StringData, "min_voltage_between_spikes",
+  setVec(DoubleFeatureData, StringData, "min_voltage_between_spikes",
                min_voltage_between_spikes);
   return min_voltage_between_spikes.size();
 }
@@ -2123,7 +2123,7 @@ int LibV5::voltage(mapStr2intVec& IntFeatureData,
     return -1;
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "voltage", v);
+  setVec(DoubleFeatureData, StringData, "voltage", v);
   return v.size();
 }
 
@@ -2142,7 +2142,7 @@ int LibV5::current(mapStr2intVec& IntFeatureData,
     return -1;
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "current", i);
+  setVec(DoubleFeatureData, StringData, "current", i);
   return i.size();
 }
 
@@ -2161,7 +2161,7 @@ int LibV5::time(mapStr2intVec& IntFeatureData,
     return -1;
   }
 
-  setDoubleVec(DoubleFeatureData, StringData, "time", t);
+  setVec(DoubleFeatureData, StringData, "time", t);
   return t.size();
 }
 
@@ -2212,7 +2212,7 @@ int LibV5::steady_state_voltage_stimend(mapStr2intVec& IntFeatureData,
     mean /= mean_size;
     ssv.push_back(mean);
 
-    setDoubleVec(DoubleFeatureData, StringData, "steady_state_voltage_stimend",
+    setVec(DoubleFeatureData, StringData, "steady_state_voltage_stimend",
                  ssv);
 
     return 1;
@@ -2277,7 +2277,7 @@ int LibV5::voltage_base(mapStr2intVec& IntFeatureData,
   }
 
   vRest.push_back(vSum / nCount);
-  setDoubleVec(DoubleFeatureData, StringData, "voltage_base", vRest);
+  setVec(DoubleFeatureData, StringData, "voltage_base", vRest);
   return 1;
 }
 
@@ -2385,7 +2385,7 @@ int LibV5::decay_time_constant_after_stim(mapStr2intVec& IntFeatureData,
 
   vector<double> dtcas;
   dtcas.push_back(val);
-  setDoubleVec(DoubleFeatureData, StringData, "decay_time_constant_after_stim",
+  setVec(DoubleFeatureData, StringData, "decay_time_constant_after_stim",
                dtcas);
 
   return 1;
@@ -2418,7 +2418,7 @@ int LibV5::voltage_deflection_vb_ssse(mapStr2intVec& IntFeatureData,
   voltage_deflection_vb_ssse.push_back(steady_state_voltage_stimend[0] -
                                        voltage_base[0]);
 
-  setDoubleVec(DoubleFeatureData, StringData, "voltage_deflection_vb_ssse",
+  setVec(DoubleFeatureData, StringData, "voltage_deflection_vb_ssse",
                voltage_deflection_vb_ssse);
   retVal = 1;
 
@@ -2450,7 +2450,7 @@ int LibV5::ohmic_input_resistance_vb_ssse(mapStr2intVec& IntFeatureData,
 
   ohmic_input_resistance_vb_ssse.push_back(voltage_deflection_vb_ssse[0] /
                                            stimulus_current[0]);
-  setDoubleVec(DoubleFeatureData, StringData, "ohmic_input_resistance_vb_ssse",
+  setVec(DoubleFeatureData, StringData, "ohmic_input_resistance_vb_ssse",
                ohmic_input_resistance_vb_ssse);
   retVal = 1;
 
@@ -2481,7 +2481,7 @@ int LibV5::maximum_voltage_from_voltagebase(mapStr2intVec& IntFeatureData,
 
   maximum_voltage_from_voltagebase.push_back(maximum_voltage[0] -
                                              voltage_base[0]);
-  setDoubleVec(DoubleFeatureData, StringData,
+  setVec(DoubleFeatureData, StringData,
                "maximum_voltage_from_voltagebase",
                maximum_voltage_from_voltagebase);
   retVal = 1;
@@ -2541,7 +2541,7 @@ int LibV5::Spikecount_stimint(mapStr2intVec& IntFeatureData,
                                         InInterval(stimstart[0], stimend[0]));
 
     vector<int> spikecount_stimint(1, spikecount_stimint_value);
-    setIntVec(IntFeatureData, StringData, "Spikecount_stimint",
+    setVec(IntFeatureData, StringData, "Spikecount_stimint",
               spikecount_stimint);
     return 1;
   }
@@ -2662,7 +2662,7 @@ int LibV5::peak_indices(mapStr2intVec& IntFeatureData,
                               strict_stiminterval, stim_start, stim_end);
 
   if (retval >= 0) {
-    setIntVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
+    setVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
   }
 
   return retval;
@@ -2715,7 +2715,7 @@ int LibV5::sag_amplitude(mapStr2intVec& IntFeatureData,
       GErrorStr += "\nsag_amplitude: voltage_deflection is positive\n";
       return -1;
   }
-  setDoubleVec(DoubleFeatureData, StringData, "sag_amplitude",
+  setVec(DoubleFeatureData, StringData, "sag_amplitude",
                sag_amplitude);
   retVal = 1;
   return retVal;
@@ -2763,7 +2763,7 @@ int LibV5::sag_ratio1(mapStr2intVec& IntFeatureData,
   } else {
       sag_ratio1.push_back(sag_amplitude[0] / (voltage_base[0] - minimum_voltage[0]));
   }
-  setDoubleVec(DoubleFeatureData, StringData, "sag_ratio1",
+  setVec(DoubleFeatureData, StringData, "sag_ratio1",
                sag_ratio1);
   retVal = 1;
   return retVal;
@@ -2811,7 +2811,7 @@ int LibV5::sag_ratio2(mapStr2intVec& IntFeatureData,
   } else {
       sag_ratio2.push_back((voltage_base[0] - steady_state_voltage_stimend[0]) / (voltage_base[0] - minimum_voltage[0]));
   }
-  setDoubleVec(DoubleFeatureData, StringData, "sag_ratio2",
+  setVec(DoubleFeatureData, StringData, "sag_ratio2",
                sag_ratio2);
   retVal = 1;
   return retVal;

--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -77,7 +77,7 @@ int LibV5::ISI_log_slope(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
   int size;
-  if (CheckInDoublemap(DoubleFeatureData, StringData, "ISI_log_slope", size)) {
+  if (CheckInMap(DoubleFeatureData, StringData, "ISI_log_slope", size)) {
     return size;
   }
   vector<double> isivalues;
@@ -100,7 +100,7 @@ int LibV5::ISI_semilog_slope(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
   int size;
-  if (CheckInDoublemap(DoubleFeatureData, StringData, "ISI_semilog_slope",
+  if (CheckInMap(DoubleFeatureData, StringData, "ISI_semilog_slope",
                        size)) {
     return size;
   }
@@ -127,7 +127,7 @@ int LibV5::ISI_log_slope_skip(mapStr2intVec& IntFeatureData,
   vector<int> maxnSpike;
   vector<double> spikeSkipf;
 
-  if (CheckInDoublemap(DoubleFeatureData, StringData, "ISI_log_slope_skip",
+  if (CheckInMap(DoubleFeatureData, StringData, "ISI_log_slope_skip",
                        size)) {
     return size;
   }
@@ -167,7 +167,7 @@ int LibV5::time_to_second_spike(mapStr2intVec& IntFeatureData,
                                 mapStr2doubleVec& DoubleFeatureData,
                                 mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "time_to_second_spike", nSize);
   if (retVal) return nSize;
 
@@ -194,7 +194,7 @@ int LibV5::time_to_last_spike(mapStr2intVec& IntFeatureData,
                               mapStr2Str& StringData) {
   int retVal, nSize;
 
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "time_to_last_spike",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "time_to_last_spike",
                             nSize);
   if (retVal) return nSize;
 
@@ -226,7 +226,7 @@ int LibV5::inv_first_ISI(mapStr2intVec& IntFeatureData,
                          mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "inv_first_ISI", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "inv_first_ISI", nSize);
   if (retVal) return nSize;
 
   vector<double> all_isi_values_vec;
@@ -251,7 +251,7 @@ int LibV5::inv_second_ISI(mapStr2intVec& IntFeatureData,
                           mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "inv_second_ISI", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "inv_second_ISI", nSize);
   if (retVal) return nSize;
 
   vector<double> all_isi_values_vec;
@@ -276,7 +276,7 @@ int LibV5::inv_third_ISI(mapStr2intVec& IntFeatureData,
                          mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "inv_third_ISI", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "inv_third_ISI", nSize);
   if (retVal) return nSize;
 
   vector<double> all_isi_values_vec;
@@ -301,7 +301,7 @@ int LibV5::inv_fourth_ISI(mapStr2intVec& IntFeatureData,
                           mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "inv_fourth_ISI", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "inv_fourth_ISI", nSize);
   if (retVal) return nSize;
 
   vector<double> all_isi_values_vec;
@@ -326,7 +326,7 @@ int LibV5::inv_fifth_ISI(mapStr2intVec& IntFeatureData,
                          mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "inv_fifth_ISI", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "inv_fifth_ISI", nSize);
   if (retVal) return nSize;
 
   vector<double> all_isi_values_vec;
@@ -351,7 +351,7 @@ int LibV5::inv_last_ISI(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "inv_last_ISI", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "inv_last_ISI", nSize);
   if (retVal) return nSize;
   vector<double> all_isi_values_vec;
   double inv_last_ISI;
@@ -373,7 +373,7 @@ int LibV5::inv_time_to_first_spike(mapStr2intVec& IntFeatureData,
                                    mapStr2doubleVec& DoubleFeatureData,
                                    mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "inv_time_to_first_spike", nSize);
   if (retVal) return nSize;
 
@@ -440,7 +440,7 @@ int LibV5::min_AHP_indices(mapStr2intVec& IntFeatureData,
                            mapStr2Str& StringData) {
   int retVal, nSize;
 
-  retVal = CheckInIntmap(IntFeatureData, StringData, "min_AHP_indices", nSize);
+  retVal = CheckInMap(IntFeatureData, StringData, "min_AHP_indices", nSize);
   if (retVal) return nSize;
 
   double stim_start, stim_end;
@@ -509,7 +509,7 @@ int LibV5::min_AHP_values(mapStr2intVec& IntFeatureData,
                           mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "min_AHP_values", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "min_AHP_values", nSize);
   if (retVal) return nSize;
   return -1;
 }
@@ -521,7 +521,7 @@ int LibV5::AHP_depth_abs(mapStr2intVec& IntFeatureData,
                          mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "AHP_depth_abs", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "AHP_depth_abs", nSize);
   if (retVal) return nSize;
 
   vector<double> vAHP;
@@ -579,7 +579,7 @@ int LibV5::spike_width1(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "spike_half_width",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "spike_half_width",
                             nSize);
   if (retVal) return nSize;
 
@@ -701,7 +701,7 @@ int LibV5::AP_begin_indices(mapStr2intVec& IntFeatureData,
   int nSize;
 
   // Check if calculated already
-  retVal = CheckInIntmap(IntFeatureData, StringData, "AP_begin_indices", nSize);
+  retVal = CheckInMap(IntFeatureData, StringData, "AP_begin_indices", nSize);
   if (retVal) {
     return nSize;
   }
@@ -771,7 +771,7 @@ int LibV5::irregularity_index(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "irregularity_index",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "irregularity_index",
                             nSize);
   if (retVal) return nSize;
 
@@ -810,7 +810,7 @@ int LibV5::number_initial_spikes(mapStr2intVec& IntFeatureData,
                                  mapStr2doubleVec& DoubleFeatureData,
                                  mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "number_initial_spikes", nSize);
   if (retVal) return nSize;
 
@@ -847,7 +847,7 @@ int LibV5::AP1_amp(mapStr2intVec& IntFeatureData,
                    mapStr2doubleVec& DoubleFeatureData,
                    mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP1_amp", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP1_amp", nSize);
   if (retVal) return nSize;
 
   vector<double> AP_amplitudes, AP1_amp;
@@ -869,7 +869,7 @@ int LibV5::APlast_amp(mapStr2intVec& IntFeatureData,
                       mapStr2doubleVec& DoubleFeatureData,
                       mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "APlast_amp", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "APlast_amp", nSize);
   if (retVal) return nSize;
   vector<double> AP_amplitudes, APlast_amp;
   int AP_amplitude_size;
@@ -892,7 +892,7 @@ int LibV5::AP1_peak(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP1_peak", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP1_peak", nSize);
   if (retVal) return nSize;
 
   vector<double> peak_voltage, AP1_peak;
@@ -914,7 +914,7 @@ int LibV5::AP2_amp(mapStr2intVec& IntFeatureData,
                    mapStr2doubleVec& DoubleFeatureData,
                    mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP2_amp", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP2_amp", nSize);
   if (retVal) return nSize;
 
   vector<double> AP_amplitudes, AP2_amp;
@@ -937,7 +937,7 @@ int LibV5::AP2_peak(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP2_peak", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP2_peak", nSize);
   if (retVal) return nSize;
 
   vector<double> peak_voltage, AP2_peak;
@@ -960,7 +960,7 @@ int LibV5::AP2_AP1_diff(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "AP2_AP1_diff", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "AP2_AP1_diff", nSize);
   if (retVal) return nSize;
 
   vector<double> AP_amplitudes, AP2_AP1_diff;
@@ -983,7 +983,7 @@ int LibV5::AP2_AP1_peak_diff(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP2_AP1_peak_diff",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP2_AP1_peak_diff",
                             nSize);
   if (retVal) return nSize;
   vector<double> peak_voltage, AP2_AP1_peak_diff;
@@ -1008,7 +1008,7 @@ int LibV5::AP1_width(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP1_width", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP1_width", nSize);
   if (retVal) return nSize;
   vector<double> spike_half_width, AP1_width;
   retVal = getVec(DoubleFeatureData, StringData, "spike_half_width",
@@ -1030,7 +1030,7 @@ int LibV5::AP2_width(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP2_width", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP2_width", nSize);
   if (retVal) return nSize;
 
   vector<double> spike_half_width, AP2_width;
@@ -1053,7 +1053,7 @@ int LibV5::APlast_width(mapStr2intVec& IntFeatureData,
                       mapStr2doubleVec& DoubleFeatureData,
                       mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "APlast_width", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "APlast_width", nSize);
   if (retVal) return nSize;
   vector<double> spike_half_width, APlast_width;
 
@@ -1090,7 +1090,7 @@ int LibV5::AHP_time_from_peak(mapStr2intVec& IntFeatureData,
                               mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "AHP_time_from_peak",
+  retval = CheckInMap(DoubleFeatureData, StringData, "AHP_time_from_peak",
                             nsize);
   if (retval) {
     return nsize;
@@ -1134,7 +1134,7 @@ int LibV5::AHP_depth_from_peak(mapStr2intVec& IntFeatureData,
                                mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "AHP_depth_from_peak", nsize);
 
   if (retval) {
@@ -1169,7 +1169,7 @@ int LibV5::AHP1_depth_from_peak(mapStr2intVec& IntFeatureData,
                                 mapStr2doubleVec& DoubleFeatureData,
                                 mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "AHP1_depth_from_peak", nSize);
   if (retVal) return nSize;
 
@@ -1195,7 +1195,7 @@ int LibV5::AHP2_depth_from_peak(mapStr2intVec& IntFeatureData,
                                 mapStr2doubleVec& DoubleFeatureData,
                                 mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "AHP2_depth_from_peak", nSize);
   if (retVal) return nSize;
 
@@ -1251,7 +1251,7 @@ int LibV5::AP_begin_width(mapStr2intVec& IntFeatureData,
                           mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "AP_begin_width", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "AP_begin_width", nSize);
   if (retVal) return nSize;
 
   vector<int> AP_begin_indices, minAHPIndex;
@@ -1297,7 +1297,7 @@ int LibV5::AP_begin_time(mapStr2intVec& IntFeatureData,
                          mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "AP_begin_time", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "AP_begin_time", nSize);
   if (retVal) return nSize;
 
   vector<int> AP_begin_indices;
@@ -1330,7 +1330,7 @@ int LibV5::AP_begin_voltage(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP_begin_voltage",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP_begin_voltage",
                             nSize);
   if (retVal) return nSize;
 
@@ -1356,7 +1356,7 @@ int LibV5::AP1_begin_voltage(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP1_begin_voltage",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP1_begin_voltage",
                             nSize);
   if (retVal) return nSize;
 
@@ -1379,7 +1379,7 @@ int LibV5::AP2_begin_voltage(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP2_begin_voltage",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP2_begin_voltage",
                             nSize);
   if (retVal) return nSize;
 
@@ -1403,7 +1403,7 @@ int LibV5::AP1_begin_width(mapStr2intVec& IntFeatureData,
                            mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "AP1_begin_width", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "AP1_begin_width", nSize);
   if (retVal) return nSize;
 
   vector<double> AP_begin_width, AP1_begin_width;
@@ -1426,7 +1426,7 @@ int LibV5::AP2_begin_width(mapStr2intVec& IntFeatureData,
                            mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "AP2_begin_width", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "AP2_begin_width", nSize);
   if (retVal) return nSize;
 
   vector<double> AP_begin_width, AP2_begin_width;
@@ -1449,7 +1449,7 @@ int LibV5::AP2_AP1_begin_width_diff(mapStr2intVec& IntFeatureData,
                                     mapStr2doubleVec& DoubleFeatureData,
                                     mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "AP2_AP1_begin_width_diff", nSize);
   if (retVal) return nSize;
 
@@ -1511,7 +1511,7 @@ int LibV5::voltage_deflection_begin(mapStr2intVec& IntFeatureData,
                                     mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "voltage_deflection_begin", nSize);
   if (retVal) return nSize;
 
@@ -1545,7 +1545,7 @@ int LibV5::is_not_stuck(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retval;
   int size;
-  retval = CheckInIntmap(IntFeatureData, StringData, "is_not_stuck", size);
+  retval = CheckInMap(IntFeatureData, StringData, "is_not_stuck", size);
   if (retval) return size;
 
   vector<double> peak_time;
@@ -1582,7 +1582,7 @@ int LibV5::voltage_after_stim(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "voltage_after_stim",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "voltage_after_stim",
                             nSize);
   if (retVal) return nSize;
 
@@ -1617,7 +1617,7 @@ int LibV5::mean_AP_amplitude(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "mean_AP_amplitude",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "mean_AP_amplitude",
                             nSize);
   if (retVal > 0) return nSize;
 
@@ -1659,7 +1659,7 @@ int LibV5::BPAPHeightLoc1(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "BPAPHeightLoc1", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "BPAPHeightLoc1", nsize);
   if (retval) return nsize;
 
   vector<double> peakvoltage;
@@ -1698,7 +1698,7 @@ int LibV5::BPAPAmplitudeLoc1(mapStr2intVec& IntFeatureData,
                              mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "BPAPAmplitudeLoc1",
+  retval = CheckInMap(DoubleFeatureData, StringData, "BPAPAmplitudeLoc1",
                             nsize);
   if (retval) return nsize;
 
@@ -1737,7 +1737,7 @@ int LibV5::BPAPAmplitudeLoc2(mapStr2intVec& IntFeatureData,
                              mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInDoublemap(DoubleFeatureData, StringData, "BPAPAmplitudeLoc2",
+  retval = CheckInMap(DoubleFeatureData, StringData, "BPAPAmplitudeLoc2",
                             nsize);
   if (retval) return nsize;
 
@@ -1777,7 +1777,7 @@ int LibV5::BPAPHeightLoc2(mapStr2intVec& IntFeatureData,
   int retval;
   int nsize;
   retval =
-      CheckInDoublemap(DoubleFeatureData, StringData, "BPAPHeightLoc2", nsize);
+      CheckInMap(DoubleFeatureData, StringData, "BPAPHeightLoc2", nsize);
   if (retval) return nsize;
 
   vector<double> peakvoltage;
@@ -1817,7 +1817,7 @@ int LibV5::check_AISInitiation(mapStr2intVec& IntFeatureData,
   int nsize;
   // printf("Started check_AISInitation\n");
 
-  retval = CheckInDoublemap(DoubleFeatureData, StringData,
+  retval = CheckInMap(DoubleFeatureData, StringData,
                             "check_AISInitiation", nsize);
   if (retval) return nsize;
 
@@ -1908,7 +1908,7 @@ int LibV5::AP_phaseslope(mapStr2intVec& IntFeatureData,
   int retVal;
   int nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "AP_phaseslope", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "AP_phaseslope", nSize);
   if (retVal) return nSize;
 
   vector<double> v;
@@ -1953,7 +1953,7 @@ int LibV5::AP_phaseslope_AIS(mapStr2intVec& IntFeatureData,
                              mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP_phaseslope_AIS",
+  retVal = CheckInMap(DoubleFeatureData, StringData, "AP_phaseslope_AIS",
                             nSize);
   if (retVal) return nSize;
 
@@ -1971,7 +1971,7 @@ int LibV5::BAC_width(mapStr2intVec& IntFeatureData,
                      mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "BAC_width", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "BAC_width", nSize);
   if (retVal) return nSize;
 
   vector<double> ap_width;
@@ -1996,7 +1996,7 @@ int LibV5::BAC_maximum_voltage(mapStr2intVec& IntFeatureData,
                                mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "BAC_maximum_voltage", nSize);
   if (retVal) return nSize;
 
@@ -2015,7 +2015,7 @@ int LibV5::all_ISI_values(mapStr2intVec& IntFeatureData,
                           mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "all_ISI_values", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "all_ISI_values", nSize);
   if (retVal) return nSize;
 
   vector<double> VecISI, pvTime;
@@ -2036,7 +2036,7 @@ int LibV5::AP_amplitude_from_voltagebase(mapStr2intVec& IntFeatureData,
                                          mapStr2doubleVec& DoubleFeatureData,
                                          mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "AP_amplitude_from_voltagebase", nSize);
   if (retVal > 0) return nSize;
 
@@ -2075,7 +2075,7 @@ int LibV5::min_voltage_between_spikes(mapStr2intVec& IntFeatureData,
                                       mapStr2doubleVec& DoubleFeatureData,
                                       mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "min_voltage_between_spikes", nSize);
   if (retVal > 0) return nSize;
 
@@ -2113,7 +2113,7 @@ int LibV5::voltage(mapStr2intVec& IntFeatureData,
                    mapStr2doubleVec& DoubleFeatureData,
                    mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "voltage", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "voltage", nSize);
   if (retVal > 0) return nSize;
 
   vector<double> v;
@@ -2132,7 +2132,7 @@ int LibV5::current(mapStr2intVec& IntFeatureData,
                    mapStr2doubleVec& DoubleFeatureData,
                    mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "current", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "current", nSize);
   if (retVal > 0) return nSize;
 
   vector<double> i;
@@ -2151,7 +2151,7 @@ int LibV5::time(mapStr2intVec& IntFeatureData,
                    mapStr2doubleVec& DoubleFeatureData,
                    mapStr2Str& StringData) {
   int retVal, nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData, "time", nSize);
+  retVal = CheckInMap(DoubleFeatureData, StringData, "time", nSize);
   if (retVal > 0) return nSize;
 
   vector<double> t;
@@ -2173,7 +2173,7 @@ int LibV5::steady_state_voltage_stimend(mapStr2intVec& IntFeatureData,
   int nSize;
   vector<double> t, v, stimEnd, stimStart, ssv;
 
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "steady_state_voltage_stimend", nSize);
   if (retVal) {
     return nSize;
@@ -2224,7 +2224,7 @@ int LibV5::voltage_base(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retVal, nSize;
   retVal =
-      CheckInDoublemap(DoubleFeatureData, StringData, "voltage_base", nSize);
+      CheckInMap(DoubleFeatureData, StringData, "voltage_base", nSize);
   if (retVal) return nSize;
 
   vector<double> v, t, stimStart, vRest, vb_start_perc_vec, vb_end_perc_vec;
@@ -2332,7 +2332,7 @@ int LibV5::decay_time_constant_after_stim(mapStr2intVec& IntFeatureData,
   int retVal;
   int nSize;
 
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "decay_time_constant_after_stim", nSize);
   if (retVal) {
     return nSize;
@@ -2398,7 +2398,7 @@ int LibV5::voltage_deflection_vb_ssse(mapStr2intVec& IntFeatureData,
                                       mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "voltage_deflection_vb_ssse", nSize);
   if (retVal) return nSize;
 
@@ -2432,7 +2432,7 @@ int LibV5::ohmic_input_resistance_vb_ssse(mapStr2intVec& IntFeatureData,
                                           mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "ohmic_input_resistance_vb_ssse", nSize);
   if (retVal) return nSize;
 
@@ -2463,7 +2463,7 @@ int LibV5::maximum_voltage_from_voltagebase(mapStr2intVec& IntFeatureData,
                                             mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "maximum_voltage_from_voltagebase", nSize);
   if (retVal) return nSize;
 
@@ -2507,7 +2507,7 @@ int LibV5::Spikecount_stimint(mapStr2intVec& IntFeatureData,
   int nsize;
   int spikecount_stimint_value;
   retval =
-      CheckInIntmap(IntFeatureData, StringData, "Spikecount_stimint", nsize);
+      CheckInMap(IntFeatureData, StringData, "Spikecount_stimint", nsize);
   if (retval) {
     return nsize;
   }
@@ -2611,7 +2611,7 @@ int LibV5::peak_indices(mapStr2intVec& IntFeatureData,
                         mapStr2Str& StringData) {
   int retVal, nSize;
 
-  retVal = CheckInIntmap(IntFeatureData, StringData, "peak_indices", nSize);
+  retVal = CheckInMap(IntFeatureData, StringData, "peak_indices", nSize);
   if (retVal) return nSize;
 
   vector<int> PeakIndex, strict_stiminterval_vec;
@@ -2672,7 +2672,7 @@ int LibV5::sag_amplitude(mapStr2intVec& IntFeatureData,
                                           mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "sag_amplitude", nSize);
   if (retVal) return nSize;
 
@@ -2726,7 +2726,7 @@ int LibV5::sag_ratio1(mapStr2intVec& IntFeatureData,
                                           mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "sag_ratio1", nSize);
   if (retVal) return nSize;
 
@@ -2774,7 +2774,7 @@ int LibV5::sag_ratio2(mapStr2intVec& IntFeatureData,
                                           mapStr2Str& StringData) {
   int retVal;
   int nSize;
-  retVal = CheckInDoublemap(DoubleFeatureData, StringData,
+  retVal = CheckInMap(DoubleFeatureData, StringData,
                             "sag_ratio2", nSize);
   if (retVal) return nSize;
 

--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -82,7 +82,7 @@ int LibV5::ISI_log_slope(mapStr2intVec& IntFeatureData,
   }
   vector<double> isivalues;
   vector<double> slope;
-  if (getDoubleVec(DoubleFeatureData, StringData, "ISI_values", isivalues) <=
+  if (getVec(DoubleFeatureData, StringData, "ISI_values", isivalues) <=
       0) {
     return -1;
   }
@@ -106,7 +106,7 @@ int LibV5::ISI_semilog_slope(mapStr2intVec& IntFeatureData,
   }
   vector<double> isivalues;
   vector<double> slope;
-  if (getDoubleVec(DoubleFeatureData, StringData, "ISI_values", isivalues) <=
+  if (getVec(DoubleFeatureData, StringData, "ISI_values", isivalues) <=
       0) {
     return -1;
   }
@@ -133,7 +133,7 @@ int LibV5::ISI_log_slope_skip(mapStr2intVec& IntFeatureData,
   }
   vector<double> isivalues;
   vector<double> slope;
-  if (getDoubleVec(DoubleFeatureData, StringData, "ISI_values", isivalues) <=
+  if (getVec(DoubleFeatureData, StringData, "ISI_values", isivalues) <=
       0) {
     return -1;
   }
@@ -174,12 +174,12 @@ int LibV5::time_to_second_spike(mapStr2intVec& IntFeatureData,
   vector<double> second_spike;
   vector<double> peaktime;
   vector<double> stimstart;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peaktime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", peaktime);
   if (retVal < 2) {
     GErrorStr += "\n Two spikes required for time_to_second_spike.\n";
     return -1;
   }
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retVal <= 0) return -1;
 
   second_spike.push_back(peaktime[1] - stimstart[0]);
@@ -201,7 +201,7 @@ int LibV5::time_to_last_spike(mapStr2intVec& IntFeatureData,
   vector<double> last_spike;
   vector<double> peaktime;
   vector<double> stimstart;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peaktime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", peaktime);
   if (retVal < 0) {
     GErrorStr += "\n Error in peak_time calculation in time_to_last_spike.\n";
     return -1;
@@ -211,7 +211,7 @@ int LibV5::time_to_last_spike(mapStr2intVec& IntFeatureData,
                  last_spike);
   } else {
     retVal =
-        getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+        getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
     if (retVal <= 0) return -1;
     last_spike.push_back(peaktime[peaktime.size() - 1] - stimstart[0]);
     setVec(DoubleFeatureData, StringData, "time_to_last_spike",
@@ -232,7 +232,7 @@ int LibV5::inv_first_ISI(mapStr2intVec& IntFeatureData,
   vector<double> all_isi_values_vec;
   double inv_first_ISI;
   vector<double> inv_first_ISI_vec;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "all_ISI_values",
+  retVal = getVec(DoubleFeatureData, StringData, "all_ISI_values",
                         all_isi_values_vec);
   if (retVal < 1) {
     inv_first_ISI = 0.0;
@@ -257,7 +257,7 @@ int LibV5::inv_second_ISI(mapStr2intVec& IntFeatureData,
   vector<double> all_isi_values_vec;
   double inv_second_ISI;
   vector<double> inv_second_ISI_vec;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "all_ISI_values",
+  retVal = getVec(DoubleFeatureData, StringData, "all_ISI_values",
                         all_isi_values_vec);
   if (retVal < 2) {
     inv_second_ISI = 0.0;
@@ -282,7 +282,7 @@ int LibV5::inv_third_ISI(mapStr2intVec& IntFeatureData,
   vector<double> all_isi_values_vec;
   double inv_third_ISI;
   vector<double> inv_third_ISI_vec;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "all_ISI_values",
+  retVal = getVec(DoubleFeatureData, StringData, "all_ISI_values",
                         all_isi_values_vec);
   if (retVal < 3) {
     inv_third_ISI = 0.0;
@@ -307,7 +307,7 @@ int LibV5::inv_fourth_ISI(mapStr2intVec& IntFeatureData,
   vector<double> all_isi_values_vec;
   double inv_fourth_ISI;
   vector<double> inv_fourth_ISI_vec;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "all_ISI_values",
+  retVal = getVec(DoubleFeatureData, StringData, "all_ISI_values",
                         all_isi_values_vec);
   if (retVal < 4) {
     inv_fourth_ISI = 0.0;
@@ -332,7 +332,7 @@ int LibV5::inv_fifth_ISI(mapStr2intVec& IntFeatureData,
   vector<double> all_isi_values_vec;
   double inv_fifth_ISI;
   vector<double> inv_fifth_ISI_vec;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "all_ISI_values",
+  retVal = getVec(DoubleFeatureData, StringData, "all_ISI_values",
                         all_isi_values_vec);
   if (retVal < 5) {
     inv_fifth_ISI = 0.0;
@@ -356,7 +356,7 @@ int LibV5::inv_last_ISI(mapStr2intVec& IntFeatureData,
   vector<double> all_isi_values_vec;
   double inv_last_ISI;
   vector<double> inv_last_ISI_vec;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "all_ISI_values",
+  retVal = getVec(DoubleFeatureData, StringData, "all_ISI_values",
                         all_isi_values_vec);
   if (retVal < 1) {
     inv_last_ISI = 0.0;
@@ -380,7 +380,7 @@ int LibV5::inv_time_to_first_spike(mapStr2intVec& IntFeatureData,
   vector<double> time_to_first_spike_vec;
   double inv_time_to_first_spike;
   vector<double> inv_time_to_first_spike_vec;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "time_to_first_spike",
+  retVal = getVec(DoubleFeatureData, StringData, "time_to_first_spike",
                         time_to_first_spike_vec);
   if (retVal < 1) {
     inv_time_to_first_spike = 0.0;
@@ -449,15 +449,15 @@ int LibV5::min_AHP_indices(mapStr2intVec& IntFeatureData,
   bool strict_stiminterval;
 
   // Get voltage
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal <= 0) return -1;
 
   // Get time
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal <= 0) return -1;
 
   // Get peak_indices
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", peak_indices);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", peak_indices);
   if (retVal < 1) {
     GErrorStr +=
         "\n At least one spike required for calculation of "
@@ -476,7 +476,7 @@ int LibV5::min_AHP_indices(mapStr2intVec& IntFeatureData,
 
   // Get stim_start
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "stim_start", stim_start_vec);
+      getVec(DoubleFeatureData, StringData, "stim_start", stim_start_vec);
   if (retVal <= 0) {
     return -1;
   } else {
@@ -485,7 +485,7 @@ int LibV5::min_AHP_indices(mapStr2intVec& IntFeatureData,
 
   /// Get stim_end
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "stim_end", stim_end_vec);
+      getVec(DoubleFeatureData, StringData, "stim_end", stim_end_vec);
   if (retVal <= 0) {
     return -1;
   } else {
@@ -525,7 +525,7 @@ int LibV5::AHP_depth_abs(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> vAHP;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "min_AHP_values", vAHP);
+  retVal = getVec(DoubleFeatureData, StringData, "min_AHP_values", vAHP);
   if (retVal < 0) return -1;
   setVec(DoubleFeatureData, StringData, "AHP_depth_abs", vAHP);
   return vAHP.size();
@@ -586,17 +586,17 @@ int LibV5::spike_width1(mapStr2intVec& IntFeatureData,
   vector<int> PeakIndex, minAHPIndex;
   vector<double> V, t, dv1, dv2, spike_width1;
   vector<double> stim_start;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
-  if (retVal < 0) return -1;
-  retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "stim_start", stim_start);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
   retVal =
-      getIntVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndex);
+      getVec(DoubleFeatureData, StringData, "stim_start", stim_start);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
+  retVal =
+      getVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndex);
+  if (retVal < 0) return -1;
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
   if (retVal < 0) return -1;
 
   // if(PeakIndex.size()<1) {GErrorStr = GErrorStr + "\nError: One spike is
@@ -708,19 +708,19 @@ int LibV5::AP_begin_indices(mapStr2intVec& IntFeatureData,
 
   // Get input parameters
   vector<double> t;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
   vector<double> stimstart;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retVal < 0) return -1;
   vector<double> stimend;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimend);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimend);
   if (retVal < 0) return -1;
   vector<int> ahpi;
-  retVal = getIntVec(IntFeatureData, StringData, "min_AHP_indices", ahpi);
+  retVal = getVec(IntFeatureData, StringData, "min_AHP_indices", ahpi);
   if (retVal < 0) return -1;
   vector<int> apbi;
 
@@ -776,7 +776,7 @@ int LibV5::irregularity_index(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> isiValues, irregularity_index;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "ISI_values", isiValues);
+  retVal = getVec(DoubleFeatureData, StringData, "ISI_values", isiValues);
   if (retVal < 0) return -1;
 
   retVal = __irregularity_index(isiValues, irregularity_index);
@@ -816,7 +816,7 @@ int LibV5::number_initial_spikes(mapStr2intVec& IntFeatureData,
 
   vector<double> peak_times, initial_perc;
   vector<int> number_initial_spikes;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peak_times);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", peak_times);
   if (retVal < 0) return -1;
 
   retVal = getDoubleParam(DoubleFeatureData, "initial_perc", initial_perc);
@@ -827,11 +827,11 @@ int LibV5::number_initial_spikes(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> stimstart;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retVal < 0) return -1;
 
   vector<double> stimend;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimend);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimend);
   if (retVal < 0) return -1;
 
   retVal = __number_initial_spikes(peak_times, stimstart[0], stimend[0],
@@ -851,7 +851,7 @@ int LibV5::AP1_amp(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> AP_amplitudes, AP1_amp;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_amplitude",
+  retVal = getVec(DoubleFeatureData, StringData, "AP_amplitude",
                         AP_amplitudes);
   if (retVal < 1) {
     setVec(DoubleFeatureData, StringData, "AP1_amp", AP1_amp);
@@ -874,7 +874,7 @@ int LibV5::APlast_amp(mapStr2intVec& IntFeatureData,
   vector<double> AP_amplitudes, APlast_amp;
   int AP_amplitude_size;
 
-  AP_amplitude_size = getDoubleVec(DoubleFeatureData, StringData,
+  AP_amplitude_size = getVec(DoubleFeatureData, StringData,
                                    "AP_amplitude", AP_amplitudes);
   if (AP_amplitude_size < 1) {
     setVec(DoubleFeatureData, StringData, "APlast_amp", APlast_amp);
@@ -897,7 +897,7 @@ int LibV5::AP1_peak(mapStr2intVec& IntFeatureData,
 
   vector<double> peak_voltage, AP1_peak;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "peak_voltage", peak_voltage);
+      getVec(DoubleFeatureData, StringData, "peak_voltage", peak_voltage);
   if (retVal < 1) {
     setVec(DoubleFeatureData, StringData, "AP1_peak", AP1_peak);
     return 0;
@@ -918,7 +918,7 @@ int LibV5::AP2_amp(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> AP_amplitudes, AP2_amp;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_amplitude",
+  retVal = getVec(DoubleFeatureData, StringData, "AP_amplitude",
                         AP_amplitudes);
   if (retVal < 2) {
     setVec(DoubleFeatureData, StringData, "AP2_amp", AP2_amp);
@@ -942,7 +942,7 @@ int LibV5::AP2_peak(mapStr2intVec& IntFeatureData,
 
   vector<double> peak_voltage, AP2_peak;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "peak_voltage", peak_voltage);
+      getVec(DoubleFeatureData, StringData, "peak_voltage", peak_voltage);
   if (retVal < 2) {
     setVec(DoubleFeatureData, StringData, "AP2_peak", AP2_peak);
     return 0;
@@ -964,7 +964,7 @@ int LibV5::AP2_AP1_diff(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> AP_amplitudes, AP2_AP1_diff;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_amplitude",
+  retVal = getVec(DoubleFeatureData, StringData, "AP_amplitude",
                         AP_amplitudes);
   if (retVal < 2) {
     setVec(DoubleFeatureData, StringData, "AP2_AP1_diff", AP2_AP1_diff);
@@ -988,7 +988,7 @@ int LibV5::AP2_AP1_peak_diff(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
   vector<double> peak_voltage, AP2_AP1_peak_diff;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "peak_voltage", peak_voltage);
+      getVec(DoubleFeatureData, StringData, "peak_voltage", peak_voltage);
   if (retVal < 2) {
     setVec(DoubleFeatureData, StringData, "AP2_AP1_peak_diff",
                  AP2_AP1_peak_diff);
@@ -1011,7 +1011,7 @@ int LibV5::AP1_width(mapStr2intVec& IntFeatureData,
   retVal = CheckInDoublemap(DoubleFeatureData, StringData, "AP1_width", nSize);
   if (retVal) return nSize;
   vector<double> spike_half_width, AP1_width;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "spike_half_width",
+  retVal = getVec(DoubleFeatureData, StringData, "spike_half_width",
                         spike_half_width);
   if (retVal < 1) {
     setVec(DoubleFeatureData, StringData, "AP1_width", AP1_width);
@@ -1034,7 +1034,7 @@ int LibV5::AP2_width(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> spike_half_width, AP2_width;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "spike_half_width",
+  retVal = getVec(DoubleFeatureData, StringData, "spike_half_width",
                         spike_half_width);
   if (retVal < 2) {
     setVec(DoubleFeatureData, StringData, "AP2_width", AP2_width);
@@ -1058,7 +1058,7 @@ int LibV5::APlast_width(mapStr2intVec& IntFeatureData,
   vector<double> spike_half_width, APlast_width;
 
   int spike_half_width_size = 
-      getDoubleVec(DoubleFeatureData, StringData, "spike_half_width",
+      getVec(DoubleFeatureData, StringData, "spike_half_width",
                         spike_half_width);
   
   if (spike_half_width_size < 1) {
@@ -1097,16 +1097,16 @@ int LibV5::AHP_time_from_peak(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> T;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "T", T);
+  retval = getVec(DoubleFeatureData, StringData, "T", T);
   if (retval < 0) return -1;
 
   vector<int> peakIndices;
-  retval = getIntVec(IntFeatureData, StringData, "peak_indices", peakIndices);
+  retval = getVec(IntFeatureData, StringData, "peak_indices", peakIndices);
   if (retval < 0) return -1;
 
   vector<int> minAHPIndices;
   retval =
-      getIntVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndices);
+      getVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndices);
   if (retval < 0) return -1;
 
   vector<double> ahpTimeFromPeak;
@@ -1142,16 +1142,16 @@ int LibV5::AHP_depth_from_peak(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> V;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  retval = getVec(DoubleFeatureData, StringData, "V", V);
   if (retval < 0) return -1;
 
   vector<int> peakIndices;
-  retval = getIntVec(IntFeatureData, StringData, "peak_indices", peakIndices);
+  retval = getVec(IntFeatureData, StringData, "peak_indices", peakIndices);
   if (retval < 0) return -1;
 
   vector<int> minAHPIndices;
   retval =
-      getIntVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndices);
+      getVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndices);
   if (retval < 0) return -1;
 
   vector<double> ahpDepthFromPeak;
@@ -1174,7 +1174,7 @@ int LibV5::AHP1_depth_from_peak(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> ahpDepthFromPeak, ahp1DepthFromPeak;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AHP_depth_from_peak",
+  retVal = getVec(DoubleFeatureData, StringData, "AHP_depth_from_peak",
                         ahpDepthFromPeak);
   if (retVal < 1) {
     setVec(DoubleFeatureData, StringData, "AHP1_depth_from_peak",
@@ -1200,7 +1200,7 @@ int LibV5::AHP2_depth_from_peak(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> ahpDepthFromPeak, ahp2DepthFromPeak;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AHP_depth_from_peak",
+  retVal = getVec(DoubleFeatureData, StringData, "AHP_depth_from_peak",
                         ahpDepthFromPeak);
   if (retVal < 2) {
     setVec(DoubleFeatureData, StringData, "AHP2_depth_from_peak",
@@ -1257,14 +1257,14 @@ int LibV5::AP_begin_width(mapStr2intVec& IntFeatureData,
   vector<int> AP_begin_indices, minAHPIndex;
   vector<double> V, t, dv1, dv2, AP_begin_width;
   vector<double> stim_start;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
   retVal =
-      getIntVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndex);
+      getVec(IntFeatureData, StringData, "min_AHP_indices", minAHPIndex);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_begin_indices",
+  retVal = getVec(IntFeatureData, StringData, "AP_begin_indices",
                      AP_begin_indices);
   if (retVal < 0) return -1;
   if (AP_begin_indices.size() < 1) {
@@ -1302,11 +1302,11 @@ int LibV5::AP_begin_time(mapStr2intVec& IntFeatureData,
 
   vector<int> AP_begin_indices;
   vector<double> V, t, AP_begin_time;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_begin_indices",
+  retVal = getVec(IntFeatureData, StringData, "AP_begin_indices",
                      AP_begin_indices);
   if (retVal < 0) return -1;
 
@@ -1336,11 +1336,11 @@ int LibV5::AP_begin_voltage(mapStr2intVec& IntFeatureData,
 
   vector<int> AP_begin_indices;
   vector<double> V, t, AP_begin_voltage;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", V);
+  retVal = getVec(DoubleFeatureData, StringData, "V", V);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_begin_indices",
+  retVal = getVec(IntFeatureData, StringData, "AP_begin_indices",
                      AP_begin_indices);
   if (retVal < 0) return -1;
 
@@ -1361,7 +1361,7 @@ int LibV5::AP1_begin_voltage(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> AP_begin_voltage, AP1_begin_voltage;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_begin_voltage",
+  retVal = getVec(DoubleFeatureData, StringData, "AP_begin_voltage",
                         AP_begin_voltage);
   if (retVal < 1) {
     setVec(DoubleFeatureData, StringData, "AP1_begin_voltage",
@@ -1384,7 +1384,7 @@ int LibV5::AP2_begin_voltage(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> AP_begin_voltage, AP2_begin_voltage;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_begin_voltage",
+  retVal = getVec(DoubleFeatureData, StringData, "AP_begin_voltage",
                         AP_begin_voltage);
   if (retVal < 2) {
     setVec(DoubleFeatureData, StringData, "AP2_begin_voltage",
@@ -1407,7 +1407,7 @@ int LibV5::AP1_begin_width(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> AP_begin_width, AP1_begin_width;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_begin_width",
+  retVal = getVec(DoubleFeatureData, StringData, "AP_begin_width",
                         AP_begin_width);
   if (retVal < 1) {
     setVec(DoubleFeatureData, StringData, "AP1_begin_width",
@@ -1430,7 +1430,7 @@ int LibV5::AP2_begin_width(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> AP_begin_width, AP2_begin_width;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_begin_width",
+  retVal = getVec(DoubleFeatureData, StringData, "AP_begin_width",
                         AP_begin_width);
   if (retVal < 2) {
     setVec(DoubleFeatureData, StringData, "AP2_begin_width",
@@ -1454,7 +1454,7 @@ int LibV5::AP2_AP1_begin_width_diff(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> AP_begin_widths, AP2_AP1_begin_width_diff;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_begin_width",
+  retVal = getVec(DoubleFeatureData, StringData, "AP_begin_width",
                         AP_begin_widths);
   if (retVal < 2) {
     setVec(DoubleFeatureData, StringData, "AP2_AP1_begin_width_diff",
@@ -1519,13 +1519,13 @@ int LibV5::voltage_deflection_begin(mapStr2intVec& IntFeatureData,
   vector<double> t;
   vector<double> stimStart;
   vector<double> stimEnd;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal < 0) return -1;
 
   vector<double> vd;
@@ -1551,12 +1551,12 @@ int LibV5::is_not_stuck(mapStr2intVec& IntFeatureData,
   vector<double> peak_time;
   vector<double> stim_start;
   vector<double> stim_end;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peak_time);
+  retval = getVec(DoubleFeatureData, StringData, "peak_time", peak_time);
   if (retval < 0) return -1;
   retval =
-      getDoubleVec(DoubleFeatureData, StringData, "stim_start", stim_start);
+      getVec(DoubleFeatureData, StringData, "stim_start", stim_start);
   if (retval < 0) return -1;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stim_end);
+  retval = getVec(DoubleFeatureData, StringData, "stim_end", stim_end);
   if (retval < 0) return -1;
 
   bool stuck = true;
@@ -1588,11 +1588,11 @@ int LibV5::voltage_after_stim(mapStr2intVec& IntFeatureData,
 
   vector<double> v, t, stimEnd, vRest;
   double startTime, endTime;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal < 0) return -1;
 
   startTime = stimEnd[0] + (t[t.size() - 1] - stimEnd[0]) * .25;
@@ -1623,7 +1623,7 @@ int LibV5::mean_AP_amplitude(mapStr2intVec& IntFeatureData,
 
   vector<double> AP_amplitude;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "AP_amplitude", AP_amplitude);
+      getVec(DoubleFeatureData, StringData, "AP_amplitude", AP_amplitude);
 
   if (retVal < 0) {
     GErrorStr += "Error calculating AP_amplitude for mean_AP_amplitude";
@@ -1912,28 +1912,28 @@ int LibV5::AP_phaseslope(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
 
   vector<double> t;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
 
   vector<double> stimStart;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal < 0) return -1;
 
   vector<double> stimEnd;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal < 0) return -1;
 
   vector<double> range_param;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_phaseslope_range",
+  retVal = getVec(DoubleFeatureData, StringData, "AP_phaseslope_range",
                         range_param);
   if (retVal < 0) return -1;
 
   vector<int> apbi;
-  retVal = getIntVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
+  retVal = getVec(IntFeatureData, StringData, "AP_begin_indices", apbi);
   if (retVal < 0) return -1;
 
   vector<double> ap_phaseslopes;
@@ -1958,7 +1958,7 @@ int LibV5::AP_phaseslope_AIS(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> ap_phaseslopes;
-  retVal = getDoubleVec(DoubleFeatureData, StringData,
+  retVal = getVec(DoubleFeatureData, StringData,
                         "AP_phaseslope;location_AIS", ap_phaseslopes);
   if (retVal < 0) return -1;
   setVec(DoubleFeatureData, StringData, "AP_phaseslope_AIS",
@@ -1975,7 +1975,7 @@ int LibV5::BAC_width(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> ap_width;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "AP_width;location_epsp",
+  retVal = getVec(DoubleFeatureData, StringData, "AP_width;location_epsp",
                         ap_width);
   if (retVal < 0) {
     GErrorStr += "\n AP_width calculation failed in BAC_width.\n";
@@ -2001,7 +2001,7 @@ int LibV5::BAC_maximum_voltage(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> ap_phaseslopes;
-  retVal = getDoubleVec(DoubleFeatureData, StringData,
+  retVal = getVec(DoubleFeatureData, StringData,
                         "maximum_voltage;location_epsp", ap_phaseslopes);
   if (retVal != 1) return -1;
 
@@ -2019,7 +2019,7 @@ int LibV5::all_ISI_values(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> VecISI, pvTime;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "peak_time", pvTime);
+  retVal = getVec(DoubleFeatureData, StringData, "peak_time", pvTime);
   if (retVal < 2) {
     GErrorStr += "\n Two spikes required for calculation of all_ISI_values.\n";
     return -1;
@@ -2043,7 +2043,7 @@ int LibV5::AP_amplitude_from_voltagebase(mapStr2intVec& IntFeatureData,
   vector<double> peakvoltage;
   vector<double> voltage_base_vec;
   double voltage_base;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "voltage_base",
+  retVal = getVec(DoubleFeatureData, StringData, "voltage_base",
                         voltage_base_vec);
   if (retVal <= 0) {
     GErrorStr +=
@@ -2053,7 +2053,7 @@ int LibV5::AP_amplitude_from_voltagebase(mapStr2intVec& IntFeatureData,
     voltage_base = voltage_base_vec[0];
   }
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "peak_voltage", peakvoltage);
+      getVec(DoubleFeatureData, StringData, "peak_voltage", peakvoltage);
   if (retVal <= 0) {
     GErrorStr +=
         "Error calculating peak_voltage for AP_amplitude_from_voltagebase";
@@ -2082,7 +2082,7 @@ int LibV5::min_voltage_between_spikes(mapStr2intVec& IntFeatureData,
   vector<int> peak_indices;
   vector<double> v;
   vector<double> min_voltage_between_spikes;
-  retVal = getIntVec(IntFeatureData, StringData, "peak_indices", peak_indices);
+  retVal = getVec(IntFeatureData, StringData, "peak_indices", peak_indices);
   if (retVal < 0) {
     GErrorStr +=
         "Error calculating peak_indices for min_voltage_between_spikes";
@@ -2093,7 +2093,7 @@ int LibV5::min_voltage_between_spikes(mapStr2intVec& IntFeatureData,
     return 0;
   }
 
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal <= 0) {
     GErrorStr += "Error getting V for min_voltage_between_spikes";
     return -1;
@@ -2117,7 +2117,7 @@ int LibV5::voltage(mapStr2intVec& IntFeatureData,
   if (retVal > 0) return nSize;
 
   vector<double> v;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) {
     GErrorStr += "Error getting V for voltage";
     return -1;
@@ -2136,7 +2136,7 @@ int LibV5::current(mapStr2intVec& IntFeatureData,
   if (retVal > 0) return nSize;
 
   vector<double> i;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "I", i);
+  retVal = getVec(DoubleFeatureData, StringData, "I", i);
   if (retVal < 0) {
     GErrorStr += "Error getting I for current";
     return -1;
@@ -2155,7 +2155,7 @@ int LibV5::time(mapStr2intVec& IntFeatureData,
   if (retVal > 0) return nSize;
 
   vector<double> t;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) {
     GErrorStr += "Error getting T for voltage";
     return -1;
@@ -2179,13 +2179,13 @@ int LibV5::steady_state_voltage_stimend(mapStr2intVec& IntFeatureData,
     return nSize;
   }
 
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", stimEnd);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal < 0) return -1;
 
   double start_time = stimEnd[0] - 0.1 * (stimEnd[0] - stimStart[0]);
@@ -2229,20 +2229,20 @@ int LibV5::voltage_base(mapStr2intVec& IntFeatureData,
 
   vector<double> v, t, stimStart, vRest, vb_start_perc_vec, vb_end_perc_vec;
   double startTime, endTime, vb_start_perc, vb_end_perc;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimStart);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", stimStart);
   if (retVal < 0) return -1;
-  retVal = getDoubleVec(DoubleFeatureData, StringData,
+  retVal = getVec(DoubleFeatureData, StringData,
                         "voltage_base_start_perc", vb_start_perc_vec);
   if (retVal == 1) {
     vb_start_perc = vb_start_perc_vec[0];
   } else {
     vb_start_perc = 0.9;
   }
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "voltage_base_end_perc",
+  retVal = getVec(DoubleFeatureData, StringData, "voltage_base_end_perc",
                         vb_end_perc_vec);
   if (retVal == 1) {
     vb_end_perc = vb_end_perc_vec[0];
@@ -2339,25 +2339,25 @@ int LibV5::decay_time_constant_after_stim(mapStr2intVec& IntFeatureData,
   }
 
   vector<double> voltages;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", voltages);
+  retVal = getVec(DoubleFeatureData, StringData, "V", voltages);
   if (retVal < 0) return -1;
 
   vector<double> times;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", times);
+  retVal = getVec(DoubleFeatureData, StringData, "T", times);
   if (retVal < 0) return -1;
 
   vector<double> vect;
 
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_end", vect);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_end", vect);
   if (retVal != 1) return -1;
   const double stimEnd = vect[0];
 
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "stim_start", vect);
+  retVal = getVec(DoubleFeatureData, StringData, "stim_start", vect);
   if (retVal != 1) return -1;
   const double stimStart = vect[0];
 
   double decay_start_after_stim, decay_end_after_stim;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "decay_start_after_stim",
+  retVal = getVec(DoubleFeatureData, StringData, "decay_start_after_stim",
                         vect);
   if (retVal == 1) {
     decay_start_after_stim = vect[0];
@@ -2366,7 +2366,7 @@ int LibV5::decay_time_constant_after_stim(mapStr2intVec& IntFeatureData,
   }
 
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "decay_end_after_stim", vect);
+      getVec(DoubleFeatureData, StringData, "decay_end_after_stim", vect);
   if (retVal == 1) {
     decay_end_after_stim = vect[0];
   } else {
@@ -2404,11 +2404,11 @@ int LibV5::voltage_deflection_vb_ssse(mapStr2intVec& IntFeatureData,
 
   vector<double> voltage_base;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "voltage_base", voltage_base);
+      getVec(DoubleFeatureData, StringData, "voltage_base", voltage_base);
   if (retVal <= 0) return -1;
 
   vector<double> steady_state_voltage_stimend;
-  retVal = getDoubleVec(DoubleFeatureData, StringData,
+  retVal = getVec(DoubleFeatureData, StringData,
                         "steady_state_voltage_stimend",
                         steady_state_voltage_stimend);
   if (retVal <= 0) return -1;
@@ -2438,7 +2438,7 @@ int LibV5::ohmic_input_resistance_vb_ssse(mapStr2intVec& IntFeatureData,
 
   vector<double> voltage_deflection_vb_ssse;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "voltage_deflection_vb_ssse",
+      getVec(DoubleFeatureData, StringData, "voltage_deflection_vb_ssse",
                    voltage_deflection_vb_ssse);
   if (retVal <= 0) return -1;
   vector<double> stimulus_current;
@@ -2468,13 +2468,13 @@ int LibV5::maximum_voltage_from_voltagebase(mapStr2intVec& IntFeatureData,
   if (retVal) return nSize;
 
   vector<double> maximum_voltage;
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "maximum_voltage",
+  retVal = getVec(DoubleFeatureData, StringData, "maximum_voltage",
                         maximum_voltage);
   if (retVal <= 0) return -1;
 
   vector<double> voltage_base;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "voltage_base", voltage_base);
+      getVec(DoubleFeatureData, StringData, "voltage_base", voltage_base);
   if (retVal <= 0) return -1;
 
   vector<double> maximum_voltage_from_voltagebase;
@@ -2514,7 +2514,7 @@ int LibV5::Spikecount_stimint(mapStr2intVec& IntFeatureData,
 
   // Get stimulus start
   vector<double> stimstart;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_start", stimstart);
+  retval = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retval <= 0) {
     GErrorStr += "\nSpikecount_stimint: stim_start not found\n";
     return -1;
@@ -2522,7 +2522,7 @@ int LibV5::Spikecount_stimint(mapStr2intVec& IntFeatureData,
 
   // Get stimulus end
   vector<double> stimend;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "stim_end", stimend);
+  retval = getVec(DoubleFeatureData, StringData, "stim_end", stimend);
   if (retval <= 0) {
     GErrorStr += "\nSpikecount_stimint: stim_start not found\n";
     return -1;
@@ -2530,7 +2530,7 @@ int LibV5::Spikecount_stimint(mapStr2intVec& IntFeatureData,
 
   // Get the times of the peaks
   vector<double> peaktimes;
-  retval = getDoubleVec(DoubleFeatureData, StringData, "peak_time", peaktimes);
+  retval = getVec(DoubleFeatureData, StringData, "peak_time", peaktimes);
 
   if (retval < 0) {
     GErrorStr += "\nSpikecount_stimint: peak_time failed\n";
@@ -2619,12 +2619,12 @@ int LibV5::peak_indices(mapStr2intVec& IntFeatureData,
   bool strict_stiminterval = false;
   double stim_start = 0.0, stim_end = 0.0;
 
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "V", v);
+  retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal <= 0) {
     return -1;
   }
 
-  retVal = getDoubleVec(DoubleFeatureData, StringData, "T", t);
+  retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal <= 0) {
     return -1;
   }
@@ -2643,7 +2643,7 @@ int LibV5::peak_indices(mapStr2intVec& IntFeatureData,
   }
 
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "stim_start", stim_start_vec);
+      getVec(DoubleFeatureData, StringData, "stim_start", stim_start_vec);
   if (retVal <= 0) {
     return -1;
   } else {
@@ -2651,7 +2651,7 @@ int LibV5::peak_indices(mapStr2intVec& IntFeatureData,
   }
 
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, "stim_end", stim_end_vec);
+      getVec(DoubleFeatureData, StringData, "stim_end", stim_end_vec);
   if (retVal <= 0) {
     return -1;
   } else {
@@ -2679,7 +2679,7 @@ int LibV5::sag_amplitude(mapStr2intVec& IntFeatureData,
   // Get steady_state_voltage_stimend
   vector<double> steady_state_voltage_stimend;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, 
+      getVec(DoubleFeatureData, StringData, 
                    "steady_state_voltage_stimend", 
                    steady_state_voltage_stimend);
   if (retVal <= 0) return -1;
@@ -2688,7 +2688,7 @@ int LibV5::sag_amplitude(mapStr2intVec& IntFeatureData,
   double voltage_deflection_stim_ssse = 0.0;
   vector<double> voltage_deflection_vb_ssse_vec;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, 
+      getVec(DoubleFeatureData, StringData, 
                    "voltage_deflection_vb_ssse", 
                    voltage_deflection_vb_ssse_vec);
   if (retVal <= 0) {
@@ -2700,7 +2700,7 @@ int LibV5::sag_amplitude(mapStr2intVec& IntFeatureData,
   // Get minimum_voltage
   vector<double> minimum_voltage;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, 
+      getVec(DoubleFeatureData, StringData, 
                    "minimum_voltage", 
                    minimum_voltage);
   if (retVal <= 0) return -1;
@@ -2733,7 +2733,7 @@ int LibV5::sag_ratio1(mapStr2intVec& IntFeatureData,
   // Get sag_amplitude
   vector<double> sag_amplitude;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, 
+      getVec(DoubleFeatureData, StringData, 
                    "sag_amplitude", 
                    sag_amplitude);
   if (retVal <= 0) return -1;
@@ -2741,7 +2741,7 @@ int LibV5::sag_ratio1(mapStr2intVec& IntFeatureData,
   // Get voltage_base
   vector<double> voltage_base;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, 
+      getVec(DoubleFeatureData, StringData, 
                    "voltage_base", 
                    voltage_base);
   if (retVal <= 0) {return -1;}
@@ -2749,7 +2749,7 @@ int LibV5::sag_ratio1(mapStr2intVec& IntFeatureData,
   // Get minimum_voltage
   vector<double> minimum_voltage;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, 
+      getVec(DoubleFeatureData, StringData, 
                    "minimum_voltage", 
                    minimum_voltage);
   if (retVal <= 0) return -1;
@@ -2781,7 +2781,7 @@ int LibV5::sag_ratio2(mapStr2intVec& IntFeatureData,
   // Get voltage_base
   vector<double> voltage_base;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, 
+      getVec(DoubleFeatureData, StringData, 
                    "voltage_base", 
                    voltage_base);
   if (retVal <= 0) {return -1;}
@@ -2789,7 +2789,7 @@ int LibV5::sag_ratio2(mapStr2intVec& IntFeatureData,
   // Get minimum_voltage
   vector<double> minimum_voltage;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, 
+      getVec(DoubleFeatureData, StringData, 
                    "minimum_voltage", 
                    minimum_voltage);
   if (retVal <= 0) return -1;
@@ -2797,7 +2797,7 @@ int LibV5::sag_ratio2(mapStr2intVec& IntFeatureData,
   // Get steady_state_voltage_stimend
   vector<double> steady_state_voltage_stimend;
   retVal =
-      getDoubleVec(DoubleFeatureData, StringData, 
+      getVec(DoubleFeatureData, StringData, 
                    "steady_state_voltage_stimend", 
                    steady_state_voltage_stimend);
   if (retVal <= 0) return -1;

--- a/efel/cppcore/mapoperations.cpp
+++ b/efel/cppcore/mapoperations.cpp
@@ -64,12 +64,12 @@ int getStrParam(mapStr2Str& StringData, const string& param, string& value) {
 }
 
 template <class T>
-void setVec(std::map<std::string, std::vector<T>>& featureData, mapStr2Str& StringData,
+void setVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
                string key, const vector<T>& value){
   string params;
   getStrParam(StringData, "params", params);
   key += params;
-  featureData[key] = value;
+  FeatureData[key] = value;
 }
 
 /*
@@ -80,33 +80,22 @@ void setVec(std::map<std::string, std::vector<T>>& featureData, mapStr2Str& Stri
  * For handling multiple traces the trace parameters are passed on to elementary
  * features in that way.
  */
-int getIntVec(mapStr2intVec& IntFeatureData, mapStr2Str& StringData,
-              string strFeature, vector<int>& v) {
+
+template <class T>
+int getVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
+                 string strFeature, vector<T>& v){
   string params;
   getStrParam(StringData, "params", params);
   strFeature += params;
-  mapStr2intVec::iterator mapstr2IntItr(IntFeatureData.find(strFeature));
-  if (mapstr2IntItr == IntFeatureData.end()) {
+
+  typename std::map<std::string, std::vector<T>>::iterator
+    mapstr2VecItr(FeatureData.find(strFeature));
+
+  if (mapstr2VecItr == FeatureData.end()) {
     GErrorStr += "\nFeature [" + strFeature + "] is missing\n";
     return -1;
   }
-  v = mapstr2IntItr->second;
-
-  return (v.size());
-}
-
-int getDoubleVec(mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData,
-                 string strFeature, vector<double>& v) {
-  string params;
-  getStrParam(StringData, "params", params);
-  strFeature += params;
-  mapStr2doubleVec::iterator mapstr2DoubleItr(
-      DoubleFeatureData.find(strFeature));
-  if (mapstr2DoubleItr == DoubleFeatureData.end()) {
-    GErrorStr += "\nFeature [" + strFeature + "] is missing\n";
-    return -1;
-  }
-  v = mapstr2DoubleItr->second;
+  v = mapstr2VecItr->second;
 
   return (v.size());
 }
@@ -243,8 +232,11 @@ int std_traces_double(mapStr2doubleVec& DoubleFeatureData,
   }
 }
 
-template void setVec(std::map<std::string, std::vector<double>>& featureData, mapStr2Str& StringData,
+template void setVec(std::map<std::string, std::vector<double>>& FeatureData, mapStr2Str& StringData,
                string key, const vector<double>& value);
-template void setVec(std::map<std::string, std::vector<int>>& featureData, mapStr2Str& StringData,
+template void setVec(std::map<std::string, std::vector<int>>& FeatureData, mapStr2Str& StringData,
                string key, const vector<int>& value);
-               
+template int getVec(std::map<std::string, std::vector<double>>& FeatureData, mapStr2Str& StringData,
+                 string strFeature, vector<double>& v);
+template int getVec(std::map<std::string, std::vector<int>>& FeatureData, mapStr2Str& StringData,
+                 string strFeature, vector<int>& v);

--- a/efel/cppcore/mapoperations.cpp
+++ b/efel/cppcore/mapoperations.cpp
@@ -100,29 +100,17 @@ int getVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& Strin
   return (v.size());
 }
 
-int CheckInIntmap(mapStr2intVec& IntFeatureData, mapStr2Str& StringData,
-                  string strFeature, int& nSize) {
+template <class T>
+int CheckInMap(std::map<std::string, std::vector<T>>& FeatureData,
+                     mapStr2Str& StringData, string strFeature, int& nSize){
   string params;
   getStrParam(StringData, "params", params);
   strFeature += params;
-  mapStr2intVec::const_iterator mapstr2IntItr(IntFeatureData.find(strFeature));
-  if (mapstr2IntItr != IntFeatureData.end()) {
-    nSize = mapstr2IntItr->second.size();
-    return 1;
-  }
-  nSize = -1;
-  return 0;
-}
+  typename std::map<std::string, std::vector<T>>::const_iterator
+   mapstr2VecItr(FeatureData.find(strFeature));
 
-int CheckInDoublemap(mapStr2doubleVec& DoubleFeatureData,
-                     mapStr2Str& StringData, string strFeature, int& nSize) {
-  string params;
-  getStrParam(StringData, "params", params);
-  strFeature += params;
-  mapStr2doubleVec::const_iterator mapstr2DoubleItr(
-      DoubleFeatureData.find(strFeature));
-  if (mapstr2DoubleItr != DoubleFeatureData.end()) {
-    nSize = mapstr2DoubleItr->second.size();
+  if (mapstr2VecItr != FeatureData.end()) {
+    nSize = mapstr2VecItr->second.size();
     return 1;
   }
   nSize = -1;
@@ -240,3 +228,7 @@ template int getVec(std::map<std::string, std::vector<double>>& FeatureData, map
                  string strFeature, vector<double>& v);
 template int getVec(std::map<std::string, std::vector<int>>& FeatureData, mapStr2Str& StringData,
                  string strFeature, vector<int>& v);
+template int CheckInMap(std::map<std::string, std::vector<double>>& FeatureData,
+                     mapStr2Str& StringData, string strFeature, int& nSize);
+template int CheckInMap(std::map<std::string, std::vector<int>>& FeatureData,
+                     mapStr2Str& StringData, string strFeature, int& nSize);

--- a/efel/cppcore/mapoperations.cpp
+++ b/efel/cppcore/mapoperations.cpp
@@ -64,7 +64,7 @@ int getStrParam(mapStr2Str& StringData, const string& param, string& value) {
 }
 
 template <class T>
-void setVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
+void setVec(std::map<std::string, std::vector<T> >& FeatureData, mapStr2Str& StringData,
                string key, const vector<T>& value){
   string params;
   getStrParam(StringData, "params", params);
@@ -82,13 +82,13 @@ void setVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& Stri
  */
 
 template <class T>
-int getVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
+int getVec(std::map<std::string, std::vector<T> >& FeatureData, mapStr2Str& StringData,
                  string strFeature, vector<T>& v){
   string params;
   getStrParam(StringData, "params", params);
   strFeature += params;
 
-  typename std::map<std::string, std::vector<T>>::iterator
+  typename std::map<std::string, std::vector<T> >::iterator
     mapstr2VecItr(FeatureData.find(strFeature));
 
   if (mapstr2VecItr == FeatureData.end()) {
@@ -101,12 +101,12 @@ int getVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& Strin
 }
 
 template <class T>
-int CheckInMap(std::map<std::string, std::vector<T>>& FeatureData,
+int CheckInMap(std::map<std::string, std::vector<T> >& FeatureData,
                      mapStr2Str& StringData, string strFeature, int& nSize){
   string params;
   getStrParam(StringData, "params", params);
   strFeature += params;
-  typename std::map<std::string, std::vector<T>>::const_iterator
+  typename std::map<std::string, std::vector<T> >::const_iterator
    mapstr2VecItr(FeatureData.find(strFeature));
 
   if (mapstr2VecItr != FeatureData.end()) {
@@ -220,15 +220,15 @@ int std_traces_double(mapStr2doubleVec& DoubleFeatureData,
   }
 }
 
-template void setVec(std::map<std::string, std::vector<double>>& FeatureData, mapStr2Str& StringData,
+template void setVec(std::map<std::string, std::vector<double> >& FeatureData, mapStr2Str& StringData,
                string key, const vector<double>& value);
-template void setVec(std::map<std::string, std::vector<int>>& FeatureData, mapStr2Str& StringData,
+template void setVec(std::map<std::string, std::vector<int> >& FeatureData, mapStr2Str& StringData,
                string key, const vector<int>& value);
-template int getVec(std::map<std::string, std::vector<double>>& FeatureData, mapStr2Str& StringData,
+template int getVec(std::map<std::string, std::vector<double> >& FeatureData, mapStr2Str& StringData,
                  string strFeature, vector<double>& v);
-template int getVec(std::map<std::string, std::vector<int>>& FeatureData, mapStr2Str& StringData,
+template int getVec(std::map<std::string, std::vector<int> >& FeatureData, mapStr2Str& StringData,
                  string strFeature, vector<int>& v);
-template int CheckInMap(std::map<std::string, std::vector<double>>& FeatureData,
+template int CheckInMap(std::map<std::string, std::vector<double> >& FeatureData,
                      mapStr2Str& StringData, string strFeature, int& nSize);
-template int CheckInMap(std::map<std::string, std::vector<int>>& FeatureData,
+template int CheckInMap(std::map<std::string, std::vector<int> >& FeatureData,
                      mapStr2Str& StringData, string strFeature, int& nSize);

--- a/efel/cppcore/mapoperations.cpp
+++ b/efel/cppcore/mapoperations.cpp
@@ -63,20 +63,13 @@ int getStrParam(mapStr2Str& StringData, const string& param, string& value) {
   return 1;
 }
 
-void setIntVec(mapStr2intVec& IntFeatureData, mapStr2Str& StringData,
-               string key, const vector<int>& value) {
+template <class T>
+void setVec(std::map<std::string, std::vector<T>>& featureData, mapStr2Str& StringData,
+               string key, const vector<T>& value){
   string params;
   getStrParam(StringData, "params", params);
   key += params;
-  IntFeatureData[key] = value;
-}
-
-void setDoubleVec(mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData,
-                  string key, const vector<double>& value) {
-  string params;
-  getStrParam(StringData, "params", params);
-  key += params;
-  DoubleFeatureData[key] = value;
+  featureData[key] = value;
 }
 
 /*
@@ -249,3 +242,9 @@ int std_traces_double(mapStr2doubleVec& DoubleFeatureData,
     return -1;
   }
 }
+
+template void setVec(std::map<std::string, std::vector<double>>& featureData, mapStr2Str& StringData,
+               string key, const vector<double>& value);
+template void setVec(std::map<std::string, std::vector<int>>& featureData, mapStr2Str& StringData,
+               string key, const vector<int>& value);
+               

--- a/efel/cppcore/mapoperations.h
+++ b/efel/cppcore/mapoperations.h
@@ -36,13 +36,13 @@ int getDoubleParam(mapStr2doubleVec& DoubleFeatureData, const string& param,
                    vector<double>& vec);
 int getStrParam(mapStr2Str& StringData, const string& param, string& value);
 template <class T>
-void setVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
+void setVec(std::map<std::string, std::vector<T> >& FeatureData, mapStr2Str& StringData,
                string key, const vector<T>& value);
 template <class T>
-int getVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
+int getVec(std::map<std::string, std::vector<T> >& FeatureData, mapStr2Str& StringData,
                  string strFeature, vector<T>& v);
 template <class T>
-int CheckInMap(std::map<std::string, std::vector<T>>& FeatureData,
+int CheckInMap(std::map<std::string, std::vector<T> >& FeatureData,
                      mapStr2Str& StringData, string strFeature, int& nSize);
 // eCode feature convenience function
 int mean_traces_double(mapStr2doubleVec& DoubleFeatureData,

--- a/efel/cppcore/mapoperations.h
+++ b/efel/cppcore/mapoperations.h
@@ -40,10 +40,10 @@ template <class T>
 void setVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
                string key, const vector<T>& value);
 
-int getDoubleVec(mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData,
-                 string strFeature, vector<double>& v);
-int getIntVec(mapStr2intVec& IntFeatureData, mapStr2Str& StringData,
-              string strFeature, vector<int>& v);
+template <class T>
+int getVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
+                 string strFeature, vector<T>& v);
+
 int CheckInDoublemap(mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData, string strFeature, int& nSize);
 int CheckInIntmap(mapStr2intVec& IntFeatureData, mapStr2Str& StringData,

--- a/efel/cppcore/mapoperations.h
+++ b/efel/cppcore/mapoperations.h
@@ -36,10 +36,9 @@ int getDoubleParam(mapStr2doubleVec& DoubleFeatureData, const string& param,
                    vector<double>& vec);
 int getStrParam(mapStr2Str& StringData, const string& param, string& value);
 
-void setIntVec(mapStr2intVec& IntFeatureData, mapStr2Str& StringData,
-               string key, const vector<int>& value);
-void setDoubleVec(mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData,
-                  string key, const vector<double>& value);
+template <class T>
+void setVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
+               string key, const vector<T>& value);
 
 int getDoubleVec(mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData,
                  string strFeature, vector<double>& v);

--- a/efel/cppcore/mapoperations.h
+++ b/efel/cppcore/mapoperations.h
@@ -44,10 +44,9 @@ template <class T>
 int getVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
                  string strFeature, vector<T>& v);
 
-int CheckInDoublemap(mapStr2doubleVec& DoubleFeatureData,
+template <class T>
+int CheckInMap(std::map<std::string, std::vector<T>>& FeatureData,
                      mapStr2Str& StringData, string strFeature, int& nSize);
-int CheckInIntmap(mapStr2intVec& IntFeatureData, mapStr2Str& StringData,
-                  string strFeature, int& nSize);
 
 // eCode feature convenience function
 int mean_traces_double(mapStr2doubleVec& DoubleFeatureData,

--- a/efel/cppcore/mapoperations.h
+++ b/efel/cppcore/mapoperations.h
@@ -35,19 +35,15 @@ int getIntParam(mapStr2intVec& IntFeatureData, const string& param,
 int getDoubleParam(mapStr2doubleVec& DoubleFeatureData, const string& param,
                    vector<double>& vec);
 int getStrParam(mapStr2Str& StringData, const string& param, string& value);
-
 template <class T>
 void setVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
                string key, const vector<T>& value);
-
 template <class T>
 int getVec(std::map<std::string, std::vector<T>>& FeatureData, mapStr2Str& StringData,
                  string strFeature, vector<T>& v);
-
 template <class T>
 int CheckInMap(std::map<std::string, std::vector<T>>& FeatureData,
                      mapStr2Str& StringData, string strFeature, int& nSize);
-
 // eCode feature convenience function
 int mean_traces_double(mapStr2doubleVec& DoubleFeatureData,
                        const string& feature, const string& stimulus_name,


### PR DESCRIPTION
Simplifies the mapoperations.h by removing the duplicated code.

* setIntVec and setDoubleVec become setVec
* getIntVec and getDoubleVec become getVec
* checkInIntmap and checkInDoubleMap become CheckInMap