### PR TITLE
Add missing <stdexcept> header for std::invalid_argument 

### DIFF
--- a/efel/cppcore/LibV5.h
+++ b/efel/cppcore/LibV5.h
@@ -23,6 +23,7 @@
 #include "Utils.h"
 
 #include <vector>
+#include <stdexcept>
 
 using std::vector;
 


### PR DESCRIPTION
GCC 4.7.x requires it.