### PR TITLE
Added sahp_start parameter.

### DIFF
--- a/efel/api.py
+++ b/efel/api.py
@@ -98,6 +98,7 @@ def reset():
     setStrSetting("voltage_base_mode", "mean")
     setStrSetting("current_base_mode", "mean")
     setDoubleSetting("precision_threshold", 1e-10)
+    setDoubleSetting("sahp_start", 5.0)
 
     _initialise()
 

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -524,16 +524,18 @@ int LibV1::AHP_depth_abs(mapStr2intVec& IntFeatureData,
 }
 
 // *** AHP_depth_abs_slow ***
-// same as AHP_depth_abs but the minimum search starts 5 ms after the spike,
+// same as AHP_depth_abs but the minimum search starts 
+// 5 ms (or custom duration) after the spike,
 // first ISI is ignored
 static int __AHP_depth_abs_slow_indices(const vector<double>& t,
                                         const vector<double>& v,
                                         const vector<int>& peakindices,
+                                        double sahp_start,
                                         vector<int>& adas_indices) {
   adas_indices.resize(peakindices.size() - 2);
   for (size_t i = 0; i < adas_indices.size(); i++) {
-    // start 5 ms after last spike
-    double t_start = t[peakindices[i + 1]] + 5;
+    // start 5 ms (or custom duration) after last spike
+    double t_start = t[peakindices[i + 1]] + sahp_start;
     adas_indices[i] = distance(
         v.begin(),
         min_element(
@@ -571,9 +573,15 @@ int LibV1::AHP_depth_abs_slow(mapStr2intVec& IntFeatureData,
         "AHP_slow_time.\n";
     return -1;
   }
+  // time after the spike in ms after which to start searching for minimum
+  vector<double> sahp_start;
+  retval = getVec(DoubleFeatureData, StringData, "sahp_start", sahp_start);
+  if (retval < 0){
+    sahp_start.push_back(5);
+  };
 
   vector<int> adas_indices;
-  retval = __AHP_depth_abs_slow_indices(t, v, peakindices, adas_indices);
+  retval = __AHP_depth_abs_slow_indices(t, v, peakindices, sahp_start[0], adas_indices);
   vector<double> ahpdepthabsslow(adas_indices.size());
   vector<double> ahpslowtime(adas_indices.size());
   for (size_t i = 0; i < adas_indices.size(); i++) {

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -2022,3 +2022,32 @@ def test_rise_time_perc():
 
     for exp, rise_time in zip(expected, ap_rise_time):
         nt.assert_almost_equal(exp, rise_time)
+
+
+def test_slow_ahp_start():
+    """basic: Test AHP_depth_abs_slow with a custom after spike start time"""
+
+    import efel
+    efel.reset()
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True
+    )
+
+    trace['sahp_start'] = [12.0]
+
+    features = ['AHP_depth_abs_slow', 'peak_indices']
+
+    feature_values = efel.getFeatureValues(
+        [trace], features, raise_warnings=False
+    )
+    peak_indices = feature_values[0]['peak_indices']
+    ahp_depth_abs_slow = feature_values[0]['AHP_depth_abs_slow']
+
+    expected = []
+    for i in range(1, len(peak_indices) - 1):
+        new_start_time = time[peak_indices[i]] + trace['sahp_start'][0]
+        new_idx = numpy.min(numpy.where(time >= new_start_time)[0])
+        expected.append(numpy.min(voltage[new_idx:peak_indices[i + 1]]))
+
+    for exp, ahp_slow in zip(expected, ahp_depth_abs_slow):
+        nt.assert_almost_equal(exp, ahp_slow)


### PR DESCRIPTION
Solves #201.

Added a sahp start parameter that defines the number of ms after each peak after which AHP_depth_abs_slow starts searching for a minimum between two peaks.

However, #201 also mentions a fast after-hyperpolarization window, but I could not manage to find such a thing in efel. It looks to me like fast AHP does not use any window. If indeed there is no such thing, then this can be merged.