### PR TITLE
min_AHP_indices: for last peak return min btw last peak and stim end

### DIFF
--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -420,13 +420,11 @@ static int __min_AHP_indices(const vector<double>& t, const vector<double>& v,
         v.begin(), first_min_element(v.begin() + peak_indices_plus[i],
                                      v.begin() + peak_indices_plus[i + 1]));
 
-    if (ahpindex != end_index - 1) {
       min_ahp_indices.push_back(ahpindex);
 
       EFEL_ASSERT(ahpindex < v.size(),
                   "AHP index falls outside of voltage array");
       min_ahp_values.push_back(v[ahpindex]);
-    }
   }
 
   return min_ahp_indices.size();

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -590,7 +590,7 @@ def test_min_AHP_indices_strict():
 
     import efel
 
-    for strict, n_of_ahp in [(False, 17), (True, 16)]:
+    for strict, n_of_ahp in [(False, 17), (True, 17)]:
         efel.reset()
         efel.setIntSetting('strict_stiminterval', strict)
 
@@ -642,8 +642,10 @@ def test_min_AHP_indices_single_peak():
         [trace], ["min_AHP_values", "min_AHP_indices", "peak_indices"])
 
     assert len(feats[0]["peak_indices"]) == 1
-    assert feats[0]["min_AHP_indices"] is None
-    assert feats[0]["min_AHP_values"] is None
+    assert len(feats[0]["min_AHP_indices"]) == 1
+    assert len(feats[0]["min_AHP_values"]) == 1
+    assert feats[0]["min_AHP_indices"][0] == 499
+    assert abs(feats[0]["min_AHP_values"][0] - (-77.5954895)) < 1e-5
 
 
 def test_strict_stiminterval():


### PR DESCRIPTION
This LibV5 feature was computing the minima for the last peak but was not returning it.
The issue emerged when the input data only had a single peak. In that case the result was None (after the bug fix #204 ). However according to the docs it should return the min between the last peak and the stim end.

The documentation goes: "Yield the indices at the voltage minima
between two peaks. For the last peak yield the minimum between
the last peak and the end of the stimulus".