### PR TITLE
Fix potential seg fault in AP_peak_upstroke

### DIFF
--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -2999,8 +2999,22 @@ static int __AP_peak_upstroke(const vector<double>& t, const vector<double>& v,
   transform(dv.begin(), dv.end(), dt.begin(), dvdt.begin(),
             std::divides<double>());
 
-  for (size_t i=0; i < std::min(apbi.size(), pi.size()); i++){
-    pus.push_back(*std::max_element(dvdt.begin()+apbi[i], dvdt.begin()+pi[i]));
+  // Make sure that each value of pi is greater than its apbi counterpart
+  vector<int> new_pi;
+  size_t j=0;
+  for (size_t i=0; i < apbi.size(); i++){
+    while (j < pi.size() && pi[j] < apbi[i]){
+      j++;
+    }
+
+    if (j < pi.size() && pi[j] >= apbi[i]){
+      new_pi.push_back(pi[j]);
+      j++;
+    }
+  }
+
+  for (size_t i=0; i < std::min(apbi.size(), new_pi.size()); i++){
+    pus.push_back(*std::max_element(dvdt.begin()+apbi[i], dvdt.begin()+new_pi[i]));
   }
 
   return pus.size();


### PR DESCRIPTION
Solves the segmentation fault from AP_peak_upstroke arising in the example code of Issue #215.

The problem was that in some cases, there is a peak indice value lower than the corresponding AP_begin_indice, probably due to an AP_begin_indice not found because below threshold.
This was solved by removing the peak_indices that do not have any lower valued AP_begin_indices.

This 'filtering' is not needed in the similar function AP_down_stroke, since no feature used there is threshold-dependent.