### PR TITLE
Fix time constant in Lib1

### DIFF
--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -1279,6 +1279,7 @@ static int __time_constant(const vector<double>& v, const vector<double>& t,
   size_t stimstartindex;
   for (stimstartindex = 0; t[stimstartindex] < stimStart; stimstartindex++)
     ;
+  // increment stimstartindex to skip a possible transient
   stimstartindex += 10;
   // int stimendindex;
   // for(stimendindex = 0; t[stimendindex] < stimEnd; stimendindex++) ;
@@ -1366,7 +1367,7 @@ static int __time_constant(const vector<double>& v, const vector<double>& t,
 
   linear_fit_result fit;
   fit = slope_straight_line_fit(t_decay, log_v);
-  double residuum = fit.average_rss;
+  double residuum = fit.normalized_std;
   bool right = true;
   double newx;
   while (x[2] - x[0] > .01) {
@@ -1382,7 +1383,7 @@ static int __time_constant(const vector<double>& v, const vector<double>& t,
     }
     fit = slope_straight_line_fit(t_decay, log_v);
 
-    if (fit.average_rss < residuum) {
+    if (fit.normalized_std < residuum) {
       if (right) {
         x[0] = x[1];
         x[1] = newx;
@@ -1390,7 +1391,7 @@ static int __time_constant(const vector<double>& v, const vector<double>& t,
         x[2] = x[1];
         x[1] = newx;
       }
-      residuum = fit.average_rss;
+      residuum = fit.normalized_std;
     } else {
       if (right) {
         x[2] = newx;

--- a/efel/cppcore/Utils.cpp
+++ b/efel/cppcore/Utils.cpp
@@ -153,6 +153,11 @@ slope_straight_line_fit(const vector<double>& x,
   }
   result.average_rss = residuals / x.size();
 
+  // calculate the normalized standard deviation
+  // the normalisation helps comparing between dataset with different ranges
+  double range = *max_element(y.begin(), y.end()) - *min_element(y.begin(), y.end());
+  result.normalized_std = residuals * x.size() / (range * range);
+
   // calculate the coefficient of determination R^2
   double y_av = sum_y / x.size();
   double sstot = 0.;

--- a/efel/cppcore/Utils.cpp
+++ b/efel/cppcore/Utils.cpp
@@ -156,7 +156,7 @@ slope_straight_line_fit(const vector<double>& x,
   // calculate the normalized standard deviation
   // the normalisation helps comparing between dataset with different ranges
   double range = *max_element(y.begin(), y.end()) - *min_element(y.begin(), y.end());
-  result.normalized_std = residuals * x.size() / (range * range);
+  result.normalized_std = residuals / (range * range);
 
   // calculate the coefficient of determination R^2
   double y_av = sum_y / x.size();

--- a/efel/cppcore/Utils.h
+++ b/efel/cppcore/Utils.h
@@ -34,6 +34,8 @@ struct linear_fit_result
   double slope;
   // average residual sum squares
   double average_rss;
+  // normalized standard deviation
+  double normalized_std;
   // coefficient of determination R^2
   double r_square;
 };


### PR DESCRIPTION
Should fix time constant for Issue #211.

I found two problems in the time constant algorithm.
1./ The start index was increased by 10 for no apparent reason (Does anyone knows why this was there?). This made the example taken form Issue #211 miss the beginning of the decay.

2./ The error estimator used in the time constant algorithm (average RSS) does not allow comparison between datasets ranging over different scales. But the scale of 'log_v' is very dependent on the 'newx' value. I decided to use the normalized standard deviation as the error estimator (which allows us to compare data at different scales).

The example from Issue #211 gives consistent time constants when using this PR.