### PR TITLE
Drop python 2.7 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [cp27, cp36, cp37, cp38, cp39]
+        python: [cp36, cp37, cp38, cp39]
         arch: [x86_64, i686, amd64, 32]
         exclude:
           - os: macos-latest
@@ -72,29 +72,8 @@ jobs:
           python-version: 3.6
       - name: Install cibuildwheel
         run: pip install cibuildwheel
-
-      # set the compiler for py27 on windows.
-      # see https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/ for details.
-      - name: set up VS build environment for windows 64 with py27
-        uses: ilammy/msvc-dev-cmd@v1
-        if: ${{ matrix.os == 'windows-latest' && matrix.python == 'cp27' && matrix.arch == 'amd64' }}
-      - name: set up VS build environment for windows 32 with py27
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x86
-        if: ${{ matrix.os == 'windows-latest' && matrix.python == 'cp27' && matrix.arch == 32 }}
-
       - name: Build wheels
         run: cibuildwheel --output-dir wheelhouse
-        if: ${{ matrix.os != 'windows-latest' || matrix.python != 'cp27' }}
-      # use MSVC 9 if py27 on windows
-      - name: Build wheels for windows with py27
-        run: cibuildwheel --output-dir wheelhouse
-        env:
-          DISTUTILS_USE_SDK: 1
-          MSSdk: 1
-        if: ${{ matrix.os == 'windows-latest' && matrix.python == 'cp27' }}
-
       - uses: actions/upload-artifact@v2
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.python }}-${{ matrix.arch }}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ library can be found [here](http://efel.readthedocs.io/en/latest/installation.ht
 News
 ====
 
+* 2021/08/25: We dropped support for Python 2.7. The eFEL code isn't automatically tested on 2.7 anymore.
+
 * 2016/01/17: We dropped support for Python 2.6. We're following the numpy and coverage module who also dropped support recently.
 For the moment eFEL still works with Python 2.6, you will just have to install the right (older) versions of the dependencies.
 The eFEL code isn't automatically tested on 2.6 anymore.
@@ -78,7 +80,7 @@ The eFEL code isn't automatically tested on 2.6 anymore.
 Requirements
 ============
 
-* [Python 2.7+](https://www.python.org/download/releases/2.7/) or [Python 3.4+](https://www.python.org/download/releases/3.4.3/)
+* [Python 3.4+](https://www.python.org/download/releases/3.4.3/)
 * [Pip](https://pip.pypa.io) (installed by default in newer versions of Python)
 * C++ compiler that can be used by pip
 * [Numpy](http://www.numpy.org) (will be installed automatically by pip)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,8 +3,7 @@ Installation
 
 Requirements
 ------------
-* `Python 2.7+ <https://www.python.org/download/releases/2.7/>`_ or
-  `Python 3.4+ <https://www.python.org/download/releases/3.4.3/>`_
+* `Python 3.4+ <https://www.python.org/download/releases/3.4.3/>`_
 * `Pip <https://pip.pypa.io>`_ (installed by default in newer versions of Python)
 * `Numpy <http://www.numpy.org>`_ (will be installed automatically by pip)
 * The instruction below are written assuming you have access to a command shell on Linux / UNIX / MacOSX / Cygwin

--- a/efel/io.py
+++ b/efel/io.py
@@ -21,15 +21,11 @@ Copyright (c) 2015, EPFL/Blue Brain Project
 
 import os
 
-# Python 2 has urlparse module, Python 3 has urllib.parse
-try:
-    import urlparse as up
-    import urllib2 as ur
-except ImportError:
-    # pylint:disable=E0611, F0401
-    import urllib.parse as up
-    import urllib.request as ur
-    # pylint:enable=E0611,F0401
+# pylint:disable=E0611, F0401
+import urllib.parse as up
+import urllib.request as ur
+
+# pylint:enable=E0611,F0401
 
 import mimetypes
 

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ setup(
         'License :: OSI Approved :: GNU Lesser General Public '
         'License v3 (LGPLv3)',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Operating System :: POSIX',
         'Topic :: Scientific/Engineering',

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
-envlist = py{27,3}-{style,test}
+envlist = py3-{style,test}
 [gh-actions]
 python =
-    2.7: py27
     3.6: py3
     3.7: py3
     3.8: py3
     3.9: py3
 [testenv]
 envdir =
-    py27{,-style,-test}: {toxworkdir}/py27
     py3{6,7,8,9,}{,-style,-test}: {toxworkdir}/py3
 deps =
     nose


### PR DESCRIPTION
  Remove py27 from github CI
  Remove py27 from tox
  Remove py27 from Readme and docs
  Remove py27 libraries in io.py

Solves Issue #222.

I'll push the 4.0 tag once this PR is approved.