### PR TITLE
Remove musllinux and i686 from wheels building

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v2
@@ -41,10 +41,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: [cp36, cp37, cp38, cp39]
-        arch: [x86_64, i686, amd64, 32]
+        arch: [x86_64, amd64, 32]
         exclude:
-          - os: macos-latest
-            arch: i686
           - os: macos-latest
             arch: amd64
           - os: macos-latest
@@ -55,12 +53,11 @@ jobs:
             arch: 32
           - os: windows-latest
             arch: x86_64
-          - os: windows-latest
-            arch: i686
     env:
       CIBW_BUILD: ${{ matrix.python }}*${{ matrix.arch }}
       CIBW_TEST_REQUIRES: nose neo[neomatlabio]>=0.5.1
       CIBW_TEST_COMMAND: nosetests -s -v -x -w {project}/efel/tests
+      CIBW_SKIP: "*-musllinux_*"
       
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- Skip musllinux wheels (that are built by default in lastest version of cibuildwheel), because we need scipy to test them, but there are no scipy wheels for this architecture
- Remove the building of manylinux-i686 wheels, as we need numpy to test them, but there are no numpy wheels for this architecture
- Also use python version in workflow yaml as string instead of floats (this would have become a problem when adding python 3.10, as with float, 3.10 would have been converted to 3.1)

Additional note: with the latest update of cibuildwheel, the new default wheel for manylinux is manylinux-2014 (previously, it was manylinux-2010)