### PR TITLE
Fix peak_indices when trace begin above threshold

### DIFF
--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -2874,7 +2874,17 @@ static int __peak_indices(double threshold, vector<double>& V,
         "\nVoltage never goes below or above threshold in spike detection.\n";
     return 0;
   }
+  if (upVec.size() == 0) {
+    GErrorStr +=
+        "\nVoltage never goes above threshold in spike detection.\n";
+    return 0;
+  }
 
+  // case where voltage starts above threshold: remove 1st dnVec
+  while (dnVec.size() > 0 && dnVec[0] < upVec[0]) {
+    dnVec.erase(dnVec.begin());
+  }
+  
   if (upVec.size() > dnVec.size()) {
     size_t size_diff = upVec.size() - dnVec.size();
     for (size_t i = 0; i < size_diff; i++) {


### PR DESCRIPTION
`Peak indices` computes the indices where the trace crosses the threshold upward and downward, then uses them to determine the peaks. When the trace begins above threshold, there is one more item in the downward crossing vector that `peak_indices` does not expects.
This makes `efel` return an empty list for `peak_indices`, and thus a `spikecount` of `0`.
This change removes any first value(s) of downward threshold crossing that is below the 1st value of upward threshold crossing.
This fixes Issue #240 