### PR TITLE
Add features to documentation, add tests, fix LibV1:time_constant and remove LibV1:threshold_current

### DIFF
--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -1288,10 +1288,10 @@ Yield the time constant of that decay.
         (slope, _), res, _, _, _ = numpy.polyfit(
             t_decay, log_v_decay, 1, full=True
         )
-        range = numpy.max(v_decay) - numpy.min(v_decay)
+        range = numpy.max(log_v_decay) - numpy.min(log_v_decay)
         return res / (range * range)
 
-    max_bound = min_derivative * 200.
+    max_bound = min_derivative * 1000.
     golden_bracket = [0, max_bound]
     result = minimize_scalar(
         numpy_fit,

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -503,6 +503,50 @@ Difference peak voltage of the second to first spike
 
     AP2_AP1_diff = peak_voltage[1] - peak_voltage[0]
 
+LibV2 : amp_drop_first_second
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Difference of the amplitude of the first and the second peak
+
+- **Required features**: LibV1:peak_voltage (mV)
+- **Units**: mV
+- **Pseudocode**: ::
+
+    amp_drop_first_second = peak_voltage[0] - peak_voltage[1]
+
+LibV2 : amp_drop_first_last
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Difference of the amplitude of the first and the last peak
+
+- **Required features**: LibV1:peak_voltage (mV)
+- **Units**: mV
+- **Pseudocode**: ::
+
+    amp_drop_first_last = peak_voltage[0] - peak_voltage[-1]
+
+LibV2 : amp_drop_second_last
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Difference of the amplitude of the second and the last peak
+
+- **Required features**: LibV1:peak_voltage (mV)
+- **Units**: mV
+- **Pseudocode**: ::
+
+    amp_drop_second_last = peak_voltage[1] - peak_voltage[-1]
+
+LibV2 : max_amp_difference
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Maximum difference of the height of two subsequent peaks
+
+- **Required features**: LibV1:peak_voltage (mV)
+- **Units**: mV
+- **Pseudocode**: ::
+
+    max_amp_difference = numpy.max(peak_voltage[:-1] - peak_voltage[1:])
+
 .. image:: _static/figures/AHP.png
 
 LibV5 : AHP_depth_abs

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -446,6 +446,18 @@ The relative height of the action potential from spike onset
     AP2_amp = AP_Amplitude[1]
     APlast_amp = AP_Amplitude[-1]
 
+LibV2 : AP_Amplitude_change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Difference of the amplitudes of the second and the first action potential
+divided by the amplitude of the first action potential
+
+- **Required features**: LibV1:AP_amplitude
+- **Units**: constant
+- **Pseudocode**: ::
+
+    AP_amplitude_change = (AP_amplitude[1:] - AP_amplitude[0]) / AP_amplitude[0]
+
 LibV5 : AP_Amplitude_from_voltagebase
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -544,6 +556,18 @@ Ignores the last spike
 
     fast_AHP = voltage[AP_begin_indices[:-1]] - voltage[min_AHP_indices[:-1]]
 
+LibV2 : fast_AHP_change
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Difference of the fast AHP of the second and the first action potential
+divided by the fast AHP of the first action potential
+
+- **Required features**: LibV2:fast_AHP
+- **Units**: constant
+- **Pseudocode**: ::
+
+    fast_AHP_change = (fast_AHP[1:] - fast_AHP[0]) / fast_AHP[0]
+
 LibV5 : AHP_depth_from_peak, AHP1_depth_from_peak, AHP2_depth_from_peak
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -631,6 +655,20 @@ Width of spike at half spike amplitude, with spike onset as described in LibV5: 
     AP_fall_indices = index_after_peak((v(peak_indices) - v(AP_begin_indices)) / 2)
     AP_duration_half_width = t(AP_fall_indices) - t(AP_rise_indices)
 
+LibV2 : AP_duration_half_width_change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Difference of the FWHM of the second and the first action potential
+divided by the FWHM of the first action potential
+
+- **Required features**: LibV2: AP_duration_half_width
+- **Units**: constant
+- **Pseudocode**: ::
+
+    AP_duration_half_width_change = (
+        AP_duration_half_width[1:] - AP_duration_half_width[0]
+    ) / AP_duration_half_width[0]
+
 LibV1 : AP_width
 ~~~~~~~~~~~~~~~~
 
@@ -659,6 +697,17 @@ Duration of an action potential from onset to offset
 - **Pseudocode**: ::
 
     AP_duration = time[AP_end_indices] - time[AP_begin_indices]
+
+LibV2 : AP_duration_change
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Difference of the durations of the second and the first action potential divided by the duration of the first action potential
+
+- **Required features**: LibV2:AP_duration
+- **Units**: constant
+- **Pseudocode**: ::
+
+    AP_duration_change = (AP_duration[1:] - AP_duration[0]) / AP_duration[0]
 
 LibV5 : AP_width_between_threshold
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -881,6 +930,30 @@ Voltage change rate during the falling phase of the action potential
     AP_fall_rate = (voltage[AP_end_indices] - voltage[peak_indices]) / (
         time[AP_end_indices] - time[peak_indices]
     )
+
+LibV2 : AP_rise_rate_change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Difference of the rise rates of the second and the first action potential
+divided by the rise rate of the first action potential
+
+- **Required features**: LibV2: AP_rise_rate_change
+- **Units**: constant
+- **Pseudocode**: ::
+
+    AP_rise_rate_change = (AP_rise_rate[1:] - AP_rise_rate[0]) / AP_rise_rate[0]
+
+LibV2 : AP_fall_rate_change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Difference of the fall rates of the second and the first action potential
+divided by the fall rate of the first action potential
+
+- **Required features**: LibV2: AP_fall_rate_change
+- **Units**: constant
+- **Pseudocode**: ::
+
+    AP_fall_rate_change = (AP_fall_rate[1:] - AP_fall_rate[0]) / AP_fall_rate[0]
 
 LibV5 : AP_phaseslope
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -446,6 +446,17 @@ The relative height of the action potential from spike onset
     AP2_amp = AP_Amplitude[1]
     APlast_amp = AP_Amplitude[-1]
 
+LibV5 : mean_AP_amplitude
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The mean of all of the action potential amplitudes
+
+- **Required features**: LibV1:AP_amplitude (mV)
+- **Units**: mV
+- **Pseudocode**: ::
+
+    mean_AP_amplitude = numpy.mean(AP_amplitude)
+
 LibV2 : AP_Amplitude_change
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -547,6 +558,17 @@ Maximum difference of the height of two subsequent peaks
 
     max_amp_difference = numpy.max(peak_voltage[:-1] - peak_voltage[1:])
 
+LibV1 : AP_amplitude_diff
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Difference of the amplitude of two subsequent peaks
+
+- **Required features**: LibV1:AP_amplitude (mV)
+- **Units**: mV
+- **Pseudocode**: ::
+
+    AP_amplitude_diff = AP_amplitude[1:] - AP_amplitude[:-1]
+
 .. image:: _static/figures/AHP.png
 
 LibV5 : AHP_depth_abs
@@ -586,6 +608,17 @@ Relative voltage values at the first after-hyperpolarization
 
     min_AHP_values = first_min_element(voltage, peak_indices)
     AHP_depth = min_AHP_values[:] - voltage_base
+
+LibV1 : AHP_depth_diff
+~~~~~~~~~~~~~~~~~~~~~~
+
+Difference of subsequent relative voltage values at the first after-hyperpolarization
+
+- **Required features**: LibV1:AHP_depth (mV)
+- **Units**: mV
+- **Pseudocode**: ::
+
+    AHP_depth_diff = AHP_depth[1:] - AHP_depth[:-1]
 
 LibV2 : fast_AHP
 ~~~~~~~~~~~~~~~~

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -556,6 +556,22 @@ Time between AP peaks and first AHP depths
     min_AHP_indices = first_min_element(voltage, peak_indices)
     AHP_time_from_peak = t[min_AHP_indices[:]] - t[peak_indices[i]]
 
+LibV3 : depolarized_base
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Mean voltage between consecutive spikes
+(from the end of one spike to the beginning of the next one)
+
+- **Required features**: LibV5:AP_end_indices, LibV5:AP_begin_indices
+- **Units**: mV
+- **Pseudocode**: ::
+
+    depolarized_base = []
+    for (start_idx, end_idx) in zip(
+        AP_end_indices[:-1], AP_begin_indices[1:])
+    ):
+        depolarized_base.append(numpy.mean(voltage[start_idx:end_idx]))
+
 LibV5 : min_voltage_between_spikes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -841,7 +841,33 @@ Time from action potential maximum to the offset
 - **Units**: ms
 - **Pseudocode**: ::
 
-    time[AP_end_indices] - time[peak_indices]
+    AP_fall_time = time[AP_end_indices] - time[peak_indices]
+
+LibV2 : AP_rise_rate
+~~~~~~~~~~~~~~~~~~~~
+
+Voltage change rate during the rising phase of the action potential
+
+- **Required features**: LibV5: AP_begin_indices, LibV5: peak_indices
+- **Units**: V/s
+- **Pseudocode**: ::
+
+    AP_rise_rate = (voltage[peak_indices] - voltage[AP_begin_indices]) / (
+        time[peak_indices] - time[AP_begin_indices]
+    )
+
+LibV2 : AP_fall_rate
+~~~~~~~~~~~~~~~~~~~~
+
+Voltage change rate during the falling phase of the action potential
+
+- **Required features**: LibV5: AP_end_indices, LibV5: peak_indices
+- **Units**: V/s
+- **Pseudocode**: ::
+
+    AP_fall_rate = (voltage[AP_end_indices] - voltage[peak_indices]) / (
+        time[AP_end_indices] - time[peak_indices]
+    )
 
 LibV5 : AP_phaseslope
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -1083,6 +1083,17 @@ The average voltage during the last 10% of the stimulus duration.
     end_time = stim_end
     steady_state_voltage_stimend = numpy.mean(voltage[numpy.where((t < end_time) & (t >= begin_time))])
 
+LibV2:steady_state_hyper
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Steady state voltage during hyperpolarization for 30 data points (after interpolation)
+
+- **Required features**: t, V, stim_start, stim_end
+- **Units**: mV
+- **Pseudocode**: ::
+
+    stim_end_idx = numpy.argwhere(time >= stim_end)[0][0]
+    steady_state_hyper = numpy.mean(voltage[stim_end_idx - 35:stim_end_idx - 5])
 
 LibV1 : steady_state_voltage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -636,6 +636,17 @@ Can use strict_stiminterval to not use minimum after stimulus end.
         offset_time[i] = t[numpy.where(v[onset_index:min_AHP_indices[i+1]] < threshold)[0]]
         AP_width[i] = t(offset_time[i]) - t(onset_time[i])
 
+LibV2 : AP_duration
+~~~~~~~~~~~~~~~~~~~
+
+Duration of an action potential from onset to offset
+
+- **Required features**: LibV5:AP_begin_indices, LibV5:AP_end_indices
+- **Units**: ms
+- **Pseudocode**: ::
+
+    AP_duration = time[AP_end_indices] - time[AP_begin_indices]
+
 LibV5 : AP_width_between_threshold
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -832,6 +832,17 @@ Time between the AP threshold and the peak, given a window
 
         rise_times.append(time[new_end_indice] - time[new_begin_indice])
 
+LibV2 : AP_fall_time
+~~~~~~~~~~~~~~~~~~~~
+
+Time from action potential maximum to the offset
+
+- **Required features**: LibV5: AP_end_indices, LibV5: peak_indices
+- **Units**: ms
+- **Pseudocode**: ::
+
+    time[AP_end_indices] - time[peak_indices]
+
 LibV5 : AP_phaseslope
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -531,6 +531,19 @@ Relative voltage values at the first after-hyperpolarization
     min_AHP_values = first_min_element(voltage, peak_indices)
     AHP_depth = min_AHP_values[:] - voltage_base
 
+LibV2 : fast_AHP
+~~~~~~~~~~~~~~~~
+
+Voltage value of the action potential onset relative to the subsequent AHP
+
+Ignores the last spike
+
+- **Required features**: LibV5:AP_begin_indices, LibV5:min_AHP_values
+- **Units**: mV
+- **Pseudocode**: ::
+
+    fast_AHP = voltage[AP_begin_indices[:-1]] - voltage[min_AHP_indices[:-1]]
+
 LibV5 : AHP_depth_from_peak, AHP1_depth_from_peak, AHP2_depth_from_peak
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -870,7 +883,7 @@ Voltage change rate during the falling phase of the action potential
     )
 
 LibV5 : AP_phaseslope
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 Slope of the V, dVdt phasespace plot at the beginning of every spike
 

--- a/efel/DependencyV5.txt
+++ b/efel/DependencyV5.txt
@@ -27,7 +27,7 @@ LibV5:ohmic_input_resistance_vb_ssse    #LibV5:voltage_deflection_vb_ssse #LibV1
 LibV1:maximum_voltage #LibV1:interpolate 
 LibV1:minimum_voltage #LibV1:interpolate 
 LibV1:steady_state_voltage #LibV1:interpolate 
-LibV3:depolarized_base #LibV1:interpolate 
+LibV3:depolarized_base #LibV5:AP_end_indices #LibV5:AP_begin_indices #LibV1:interpolate
 LibV1:ISI_CV	#LibV1:ISI_values #LibV1:interpolate 
 LibV1:Spikecount	#LibV5:peak_indices #LibV1:interpolate 
 LibV5:Spikecount_stimint	#LibV1:peak_time #LibV1:interpolate 

--- a/efel/DependencyV5.txt
+++ b/efel/DependencyV5.txt
@@ -26,7 +26,6 @@ LibV1:ohmic_input_resistance    #LibV1:voltage_deflection #LibV1:interpolate
 LibV5:ohmic_input_resistance_vb_ssse    #LibV5:voltage_deflection_vb_ssse #LibV1:interpolate 
 LibV1:maximum_voltage #LibV1:interpolate 
 LibV1:minimum_voltage #LibV1:interpolate 
-LibV1:threshold_current #LibV1:interpolate 
 LibV1:steady_state_voltage #LibV1:interpolate 
 LibV3:depolarized_base #LibV1:interpolate 
 LibV1:ISI_CV	#LibV1:ISI_values #LibV1:interpolate 

--- a/efel/cppcore/FillFptrTable.cpp
+++ b/efel/cppcore/FillFptrTable.cpp
@@ -59,7 +59,6 @@ int FillFptrTable() {
   FptrTableV1["burst_number"] = &LibV1::burst_number;
   FptrTableV1["AP_amplitude_diff"] = &LibV1::AP_amplitude_diff;
   FptrTableV1["AHP_depth_diff"] = &LibV1::AHP_depth_diff;
-  FptrTableV1["threshold_current"] = &LibV1::threshold_current;
 
   //****************** for FptrTableV1 *****************************
 

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -1721,22 +1721,6 @@ int LibV1::single_burst_ratio(mapStr2intVec& IntFeatureData,
   return retval;
 }
 
-// *** threshold_current ***
-// just return the value for threshold_current which has been inserted
-int LibV1::threshold_current(mapStr2intVec& IntFeatureData,
-                             mapStr2doubleVec& DoubleFeatureData,
-                             mapStr2Str& StringData) {
-  int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "threshold_current", nsize);
-  if (retval) {
-    return nsize;
-  }
-  return retval;
-}
-// end of threshold_current
-
 int LibV1::printVectorI(char* strName, vector<int> vec) {
   size_t nSize = 0;
   vector<int>::iterator pos1, pos2;

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -1358,8 +1358,8 @@ static int __time_constant(const vector<double>& v, const vector<double>& t,
   // golden section search algorithm
   const double PHI = 1.618033988;
   vector<double> x(3, .0);
-  // time_constant is searched in between 0 and 200 ms
-  x[2] = min_derivative * 200.;
+  // time_constant is searched in between 0 and 1000 ms
+  x[2] = min_derivative * 1000.;
   x[1] = (x[0] * PHI + x[2]) / (1. + PHI);
   // calculate residuals at x[1]
   for (size_t i = 0; i < log_v.size(); i++) {

--- a/efel/cppcore/LibV1.h
+++ b/efel/cppcore/LibV1.h
@@ -124,9 +124,6 @@ int AHP_depth(mapStr2intVec& IntFeatureData,
 int single_burst_ratio(mapStr2intVec& IntFeatureData,
                        mapStr2doubleVec& DoubleFeatureData,
                        mapStr2Str& StringData);
-int threshold_current(mapStr2intVec& IntFeatureData,
-                      mapStr2doubleVec& DoubleFeatureData,
-                      mapStr2Str& StringData);
 
 int AP_width(mapStr2intVec& IntFeatureData, mapStr2doubleVec& DoubleFeatureData,
              mapStr2Str& StringData);

--- a/efel/tests/DependencyV5_LibV4peakindices.txt
+++ b/efel/tests/DependencyV5_LibV4peakindices.txt
@@ -24,7 +24,6 @@ LibV1:ohmic_input_resistance    #LibV1:voltage_deflection
 LibV1:maximum_voltage
 LibV1:minimum_voltage
 LibV1:interpolate
-LibV1:threshold_current
 LibV1:steady_state_voltage
 LibV3:depolarized_base
 LibV1:ISI_CV	#LibV1:ISI_values

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -2663,9 +2663,6 @@ def test_time_constant():
 
     py_tau = py_time_constant(time, voltage, stim_start, stim_end)
 
-    print(f"efel: {time_cst}")
-    print(f"python : {py_tau}")
-
     # some difference because precision difference
     # between efel and python implementation
     # gets amplified by function such as log and fitting
@@ -3013,4 +3010,80 @@ def test_max_amp_difference():
 
     numpy.testing.assert_allclose(
         max_amp_difference, expected
+    )
+
+
+def test_AP_amplitude_diff():
+    """basic: Test AP amplitude diff"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["AP_amplitude_diff", "AP_amplitude"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    AP_amplitude_diff = feature_values[0]['AP_amplitude_diff']
+    AP_amplitude = feature_values[0]['AP_amplitude']
+
+    expected = AP_amplitude[1:] - AP_amplitude[:-1]
+
+    numpy.testing.assert_allclose(
+        AP_amplitude_diff, expected
+    )
+
+
+def test_AHP_depth_diff():
+    """basic: Test AHP depth diff"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["AHP_depth_diff", "AHP_depth"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    AHP_depth_diff = feature_values[0]['AHP_depth_diff']
+    AHP_depth = feature_values[0]['AHP_depth']
+
+    expected = AHP_depth[1:] - AHP_depth[:-1]
+
+    numpy.testing.assert_allclose(
+        AHP_depth_diff, expected
+    )
+
+
+def test_mean_AP_amplitude():
+    """basic: Test mean AP amplitude"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["mean_AP_amplitude", "AP_amplitude"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    mean_AP_amplitude = feature_values[0]['mean_AP_amplitude']
+    AP_amplitude = feature_values[0]['AP_amplitude']
+
+    numpy.testing.assert_allclose(
+        mean_AP_amplitude, numpy.mean(AP_amplitude)
     )

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -2809,3 +2809,68 @@ def test_fast_AHP():
     ]
 
     numpy.testing.assert_allclose(fast_AHP, py_fast_AHP)
+
+
+def check_change_feature(change_name, base_name):
+    """Test for a 'change' feature
+
+    E.g. change_name='AP_duration_change', base_name='AP_duration'
+    """
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = [change_name, base_name]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    base = feature_values[0][base_name]
+    change = feature_values[0][change_name]
+
+    py_change = (base[1:] - base[0]) / base[0]
+
+    numpy.testing.assert_allclose(change, py_change)
+
+
+def test_AP_amplitude_change():
+    """basic: Test AP amplitude change"""
+
+    check_change_feature("AP_amplitude_change", "AP_amplitude")
+
+
+def test_AP_duration_change():
+    """basic: Test AP duration change"""
+
+    check_change_feature("AP_duration_change", "AP_duration")
+
+
+def test_AP_rise_rate_change():
+    """basic: Test AP rise rate change"""
+
+    check_change_feature("AP_rise_rate_change", "AP_rise_rate")
+
+
+def test_AP_fall_rate_change():
+    """basic: Test AP fall rate change"""
+
+    check_change_feature("AP_fall_rate_change", "AP_fall_rate")
+
+
+def test_fast_AHP_change():
+    """basic: Test fast AHP change"""
+
+    check_change_feature("fast_AHP_change", "fast_AHP")
+
+
+def test_AP_duration_half_width_change():
+    """basic: Test AP duration half width change"""
+
+    check_change_feature(
+        "AP_duration_half_width_change", "AP_duration_half_width"
+    )

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -2636,6 +2636,8 @@ def test_time_constant():
     import efel
     efel.reset()
 
+    # here, use hyperpolarized_url because sagtrace1_url falls 'too fast'
+    # for golden search bounds as defined in efel
     time = efel.io.load_fragment('%s#col=1' % hyperpolarized_url)
     voltage = efel.io.load_fragment('%s#col=2' % hyperpolarized_url)
     stim_start = 419.995
@@ -2660,6 +2662,9 @@ def test_time_constant():
     time_cst = time_cst[0]
 
     py_tau = py_time_constant(time, voltage, stim_start, stim_end)
+
+    print(f"efel: {time_cst}")
+    print(f"python : {py_tau}")
 
     # some difference because precision difference
     # between efel and python implementation
@@ -2911,3 +2916,101 @@ def test_steady_state_hyper():
     expected = numpy.mean(voltage[stim_end_idx - 35:stim_end_idx - 5])
 
     numpy.testing.assert_allclose(steady_state_hyper, expected)
+
+
+def test_amp_drop_first_second():
+    """basic: Test amp drop first second"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["amp_drop_first_second", "peak_voltage"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    amp_drop_first_second = feature_values[0]['amp_drop_first_second']
+    peak_voltage = feature_values[0]['peak_voltage']
+
+    numpy.testing.assert_allclose(
+        amp_drop_first_second, peak_voltage[0] - peak_voltage[1]
+    )
+
+
+def test_amp_drop_first_last():
+    """basic: Test amp drop first last"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["amp_drop_first_last", "peak_voltage"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    amp_drop_first_last = feature_values[0]['amp_drop_first_last']
+    peak_voltage = feature_values[0]['peak_voltage']
+
+    numpy.testing.assert_allclose(
+        amp_drop_first_last, peak_voltage[0] - peak_voltage[-1]
+    )
+
+
+def test_amp_drop_second_last():
+    """basic: Test amp drop second last"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["amp_drop_second_last", "peak_voltage"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    amp_drop_second_last = feature_values[0]['amp_drop_second_last']
+    peak_voltage = feature_values[0]['peak_voltage']
+
+    numpy.testing.assert_allclose(
+        amp_drop_second_last, peak_voltage[1] - peak_voltage[-1]
+    )
+
+
+def test_max_amp_difference():
+    """basic: Test max amp difference"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["max_amp_difference", "peak_voltage"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    max_amp_difference = feature_values[0]['max_amp_difference']
+    peak_voltage = feature_values[0]['peak_voltage']
+
+    expected = numpy.max(peak_voltage[:-1] - peak_voltage[1:])
+
+    numpy.testing.assert_allclose(
+        max_amp_difference, expected
+    )

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -2725,3 +2725,57 @@ def test_AP_duration():
     py_AP_dur = time[AP_end_indices] - time[AP_begin_indices]
 
     numpy.testing.assert_allclose(AP_durations, py_AP_dur)
+
+
+def test_AP_rise_rate():
+    """basic: Test AP rise rate"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["AP_rise_rate", "AP_begin_indices", "peak_indices"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    AP_begin_indices = feature_values[0]['AP_begin_indices']
+    peak_indices = feature_values[0]['peak_indices']
+    AP_rise_rate = feature_values[0]['AP_rise_rate']
+
+    py_AP_rise_rate = (voltage[peak_indices] - voltage[AP_begin_indices]) / (
+        time[peak_indices] - time[AP_begin_indices]
+    )
+
+    numpy.testing.assert_allclose(AP_rise_rate, py_AP_rise_rate)
+
+
+def test_AP_fall_rate():
+    """basic: Test AP fall rate"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["AP_fall_rate", "AP_end_indices", "peak_indices"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    AP_end_indices = feature_values[0]['AP_end_indices']
+    peak_indices = feature_values[0]['peak_indices']
+    AP_fall_rate = feature_values[0]['AP_fall_rate']
+
+    py_AP_fall_rate = (voltage[AP_end_indices] - voltage[peak_indices]) / (
+        time[AP_end_indices] - time[peak_indices]
+    )
+
+    numpy.testing.assert_allclose(AP_fall_rate, py_AP_fall_rate)

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -2675,3 +2675,29 @@ def test_depolarized_base():
         py_dep_base.append(numpy.mean(voltage[start_idx:end_idx]))
 
     numpy.testing.assert_allclose(depolarized_base, py_dep_base)
+
+
+def test_AP_duration():
+    """basic: Test AP duration"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["AP_duration", "AP_begin_indices", "AP_end_indices"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    AP_begin_indices = feature_values[0]['AP_begin_indices']
+    AP_end_indices = feature_values[0]['AP_end_indices']
+    AP_durations = feature_values[0]['AP_duration']
+
+    # works here because we use the same interpolation as in efel
+    py_AP_dur = time[AP_end_indices] - time[AP_begin_indices]
+
+    numpy.testing.assert_allclose(AP_durations, py_AP_dur)

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -2747,6 +2747,7 @@ def test_AP_rise_rate():
     peak_indices = feature_values[0]['peak_indices']
     AP_rise_rate = feature_values[0]['AP_rise_rate']
 
+    # works here because we use the same interpolation as in efel
     py_AP_rise_rate = (voltage[peak_indices] - voltage[AP_begin_indices]) / (
         time[peak_indices] - time[AP_begin_indices]
     )
@@ -2774,8 +2775,37 @@ def test_AP_fall_rate():
     peak_indices = feature_values[0]['peak_indices']
     AP_fall_rate = feature_values[0]['AP_fall_rate']
 
+    # works here because we use the same interpolation as in efel
     py_AP_fall_rate = (voltage[AP_end_indices] - voltage[peak_indices]) / (
         time[AP_end_indices] - time[peak_indices]
     )
 
     numpy.testing.assert_allclose(AP_fall_rate, py_AP_fall_rate)
+
+
+def test_fast_AHP():
+    """basic: Test fast AHP"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["fast_AHP", "AP_begin_indices", "min_AHP_indices"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    AP_begin_indices = feature_values[0]['AP_begin_indices']
+    min_AHP_indices = feature_values[0]['min_AHP_indices']
+    fast_AHP = feature_values[0]['fast_AHP']
+
+    # works here because we use the same interpolation as in efel
+    py_fast_AHP = voltage[AP_begin_indices[:-1]] - voltage[
+        min_AHP_indices[:-1]
+    ]
+
+    numpy.testing.assert_allclose(fast_AHP, py_fast_AHP)

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -2874,3 +2874,40 @@ def test_AP_duration_half_width_change():
     check_change_feature(
         "AP_duration_half_width_change", "AP_duration_half_width"
     )
+
+
+def test_steady_state_hyper():
+    """basic: Test steady state hyper"""
+
+    import efel
+    efel.reset()
+
+    stim_start = 800.0
+    stim_end = 3800.0
+
+    time = efel.io.load_fragment('%s#col=1' % sagtrace1_url)
+    voltage = efel.io.load_fragment('%s#col=2' % sagtrace1_url)
+
+    trace = {}
+
+    trace['T'] = time
+    trace['V'] = voltage
+    trace['stim_start'] = [stim_start]
+    trace['stim_end'] = [stim_end]
+
+    time, voltage = interpolate(time, voltage, 0.1)
+
+    features = ["steady_state_hyper"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    steady_state_hyper = feature_values[0]['steady_state_hyper']
+
+    # works here because we use the same interpolation as in efel
+    stim_end_idx = numpy.argwhere(time >= stim_end)[0][0]
+    expected = numpy.mean(voltage[stim_end_idx - 35:stim_end_idx - 5])
+
+    numpy.testing.assert_allclose(steady_state_hyper, expected)

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -2162,6 +2162,30 @@ def test_rise_time_perc():
         numpy.testing.assert_allclose(exp, rise_time)
 
 
+def test_fall_time():
+    """basic: Test AP fall time"""
+
+    import efel
+    efel.reset()
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True
+    )
+
+    features = ['AP_fall_time', 'AP_end_indices', 'peak_indices']
+
+    feature_values = efel.getFeatureValues(
+        [trace], features, raise_warnings=False
+    )
+    ap_fall_time = feature_values[0]['AP_fall_time']
+    AP_end_indices = feature_values[0]['AP_end_indices']
+    peak_indices = feature_values[0]['peak_indices']
+
+    # works because we have the same interpolation as in efel
+    expected = time[AP_end_indices] - time[peak_indices]
+
+    numpy.testing.assert_allclose(ap_fall_time, expected)
+
+
 def test_slow_ahp_start():
     """basic: Test AHP_depth_abs_slow with a custom after spike start time"""
 

--- a/efel/tests/testdata/allfeatures/expectedresults.json
+++ b/efel/tests/testdata/allfeatures/expectedresults.json
@@ -30549,7 +30549,7 @@
         2999.799999998367
     ],
     "time_constant": [
-        0.7140737703721047
+        0.832345371134732
     ],
     "time_to_first_spike": [
         8.000000000092427
@@ -60590,7 +60590,9 @@
     "initburst_sahp_vb": null,
     "initburst_sahp_ssse": null,
     "depol_block": null,
-    "depol_block_bool": [1],
+    "depol_block_bool": [
+        1
+    ],
     "BPAPHeightLoc1": [
         44.759481866542046
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     pytest
     pytest-cov
     coverage
+    scipy
     style: pycodestyle
 whitelist_externals =
     make


### PR DESCRIPTION
Added to documentation and added tests to:
- time_constant
- depolarized_base
- AP_duration
- AP_rise_rate
- AP_fall_rate
- fast_AHP
- AP_amplitude_change
- AP_duration_change
- AP_rise_rate_change
- AP_fall_rate_change
- fast_AHP_change
- AP_duration_half_width_change
- steady_state_hyper
- amp_drop_first_second
- amp_drop_first_last
- amp_drop_second_last
- max_amp_difference
- AP_amplitude_diff
- AHP_depth_diff
- mean_AP_amplitude

Removed LibV1:threshold_current, which was unreachable

Fixed depolarized_base, which was always returning none

Fixed time_constant, which returned wrong values for some traces, due to limited bounds in its golden section search algorithm. Solves Issue #255