### PR TITLE
Add new burst detection implementation

### DIFF
--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -378,6 +378,26 @@ then the spikes are not considered to be part of any burst
 
     return burst_mean_freq
 
+LibV5 : strict_burst_mean_freq
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The mean frequency during a burst for each burst
+
+This implementation does not assume that every spike belongs to a burst.
+
+- **Required features**: burst_begin_indices, burst_end_indices, peak_time
+- **Units**: Hz
+- **Pseudocode**: ::
+
+    if burst_begin_indices is None or burst_end_indices is None:
+        strict_burst_mean_freq = None
+    else:
+        strict_burstmean_freq = (
+            (burst_end_indices - burst_begin_indices + 1) * 1000 / (
+                peak_time[burst_end_indices] - peak_time[burst_begin_indices]
+            )
+        )
+
 LibV1 : burst_number
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -388,6 +408,19 @@ The number of bursts
 - **Pseudocode**: ::
 
     burst_number = len(burst_mean_freq)
+
+LibV5 : strict_burst_number
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The number of bursts
+
+This implementation does not assume that every spike belongs to a burst.
+
+- **Required features**: strict_burst_mean_freq
+- **Units**: constant
+- **Pseudocode**: ::
+
+    burst_number = len(strict_burst_mean_freq)
 
 LibV1 : interburst_voltage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -412,6 +445,32 @@ Starting 5 ms after that peak take the voltage average until 5 ms before the fir
         end_idx = numpy.argwhere(time > t_end)[0][0]
 
         interburst_voltage.append(numpy.mean(voltage[start_idx:end_idx + 1]))
+
+LibV5 : strict_interburst_voltage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The voltage average in between two bursts
+
+Iterating over the burst indices determine the first peak of each burst.
+Starting 5 ms after the previous peak, take the voltage average until 5 ms before the peak.
+
+This implementation does not assume that every spike belongs to a burst.
+
+- **Required features**: burst_begin_indices, peak_indices
+- **Units**: mV
+- **Pseudocode**: ::
+
+    interburst_voltage = []
+    for idx in burst_begin_idxs[1:]:
+        ts_idx = peak_idxs[idx - 1]
+        t_start = t[ts_idx] + 5
+        start_idx = numpy.argwhere(t < t_start)[-1][0]
+
+        te_idx = peak_idxs[idx]
+        t_end = t[te_idx] - 5
+        end_idx = numpy.argwhere(t > t_end)[0][0]
+
+        interburst_voltage.append(numpy.mean(v[start_idx:end_idx + 1]))
 
 LibV1 : single_burst_ratio
 ~~~~~~~~~~~~~~~~~~~~

--- a/efel/DependencyV5.txt
+++ b/efel/DependencyV5.txt
@@ -161,3 +161,8 @@ LibV5:AP_peak_downstroke   #LibV5:min_AHP_indices #LibV5:peak_indices #LibV1:int
 LibV5:min_between_peaks_indices 	    #LibV5:peak_indices #LibV1:interpolate 
 LibV5:min_between_peaks_values 	    #LibV5:min_between_peaks_indices #LibV1:interpolate 
 LibV5:AP_width_between_threshold    #LibV5:min_between_peaks_indices #LibV1:interpolate 
+LibV5:burst_begin_indices    #LibV5:all_ISI_values #LibV1:interpolate
+LibV5:burst_end_indices    #LibV5:burst_begin_indices #LibV1:interpolate
+LibV5:strict_burst_mean_freq    #LibV1:peak_time #LibV5:burst_begin_indices #LibV5:burst_end_indices #LibV1:interpolate
+LibV5:strict_burst_number    #LibV5:strict_burst_mean_freq #LibV1:interpolate
+LibV5:strict_interburst_voltage    #LibV5:peak_indices #LibV5:burst_begin_indices #LibV1:interpolate

--- a/efel/api.py
+++ b/efel/api.py
@@ -81,7 +81,7 @@ def reset():
         'DownDerivativeThreshold',
         _settings.down_derivative_threshold)
     setDoubleSetting('interp_step', 0.1)
-    setDoubleSetting('burst_factor', 1.5)
+    setDoubleSetting('burst_factor', 2.0)
     setDoubleSetting('voltage_base_start_perc', 0.9)
     setDoubleSetting('voltage_base_end_perc', 1.0)
     setDoubleSetting('current_base_start_perc', 0.9)

--- a/efel/api.py
+++ b/efel/api.py
@@ -81,7 +81,8 @@ def reset():
         'DownDerivativeThreshold',
         _settings.down_derivative_threshold)
     setDoubleSetting('interp_step', 0.1)
-    setDoubleSetting('burst_factor', 2.0)
+    setDoubleSetting('burst_factor', 1.5)
+    setDoubleSetting('strict_burst_factor', 2.0)
     setDoubleSetting('voltage_base_start_perc', 0.9)
     setDoubleSetting('voltage_base_end_perc', 1.0)
     setDoubleSetting('current_base_start_perc', 0.9)

--- a/efel/cppcore/FillFptrTable.cpp
+++ b/efel/cppcore/FillFptrTable.cpp
@@ -271,6 +271,12 @@ int FillFptrTable() {
   FptrTableV5["min_between_peaks_indices"] = &LibV5::min_between_peaks_indices;
   FptrTableV5["min_between_peaks_values"] = &LibV5::min_between_peaks_values;
   FptrTableV5["AP_width_between_threshold"] = &LibV5::AP_width_between_threshold;
+
+  FptrTableV5["burst_begin_indices"] = &LibV5::burst_begin_indices;
+  FptrTableV5["burst_end_indices"] = &LibV5::burst_end_indices;
+  FptrTableV5["strict_burst_mean_freq"] = &LibV5::strict_burst_mean_freq;
+  FptrTableV5["strict_burst_number"] = &LibV5::strict_burst_number;
+  FptrTableV5["strict_interburst_voltage"] = &LibV5::strict_interburst_voltage;
   
   //****************** end of FptrTableV5 *****************************
 

--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -3491,7 +3491,6 @@ static int __burst_indices(double burst_factor, const vector<double> ISI_values,
       dMedian = ISIpcopy[int(n / 2)];
     }
 
-    // in_burst = (burst_end_indices.size() < burst_begin_indices.size())
     in_burst = (burst_end_indices.size() == 0 || burst_begin_indices.back() > burst_end_indices.back());
 
     // look for end burst
@@ -3499,11 +3498,7 @@ static int __burst_indices(double burst_factor, const vector<double> ISI_values,
       burst_end_indices.push_back(i);
       count = i;
     }
-    // // look for begin burst
-    // if (!in_burst && (ISI_values[i] < ISI_values[i - 1] / burst_factor)){
-    //   burst_begin_indices.push_back(i);
-    //   count = i;
-    // }
+
     if (ISI_values[i] < ISI_values[i - 1] / burst_factor){
       if (in_burst){
         burst_begin_indices.back() = i;
@@ -3514,35 +3509,11 @@ static int __burst_indices(double burst_factor, const vector<double> ISI_values,
     }
   }
 
-  // if no end detected for last burst, add last peak index as last burst end
-  // use size() and not size() - 1 because we want the last peak index
-  // in_burst = (burst_end_indices.size() < burst_begin_indices.size())
   in_burst = (burst_end_indices.size() == 0 || burst_begin_indices.back() > burst_end_indices.back());
   if (in_burst){
     burst_end_indices.push_back(ISI_values.size());
   }
 
-  // // do the same backward for the first burst, to remove any isolated spike
-  // count = min(burst_end_indices.front() + 1, burst_end_indices.size() - 1)
-  // for (size_t i = count - 1; i >= first_ISI; i--) {
-  //   // get median
-  //   ISIpcopy.clear();
-  //   for (size_t j = count; j > i; j--) ISIpcopy.push_back(ISI_values[j]);
-  //   sort(ISIpcopy.begin(), ISIpcopy.end());
-  //   n = ISIpcopy.size();
-  //   if ((n % 2) == 0) {
-  //     dMedian =
-  //         (ISIpcopy[int((n - 1) / 2)] + ISIpcopy[int((n - 1) / 2) + 1]) / 2;
-  //   } else {
-  //     dMedian = ISIpcopy[int(n / 2)];
-  //   }
-
-  //   // look for begin burst
-  //   if (ISI_values[i] > (burst_factor * dMedian)){
-  //     burst_begin_indices.front = i + 1;
-  //     break;
-  //   }
-  // }
   return burst_begin_indices.size();
 }
 

--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -3537,7 +3537,7 @@ int LibV5::burst_begin_indices(mapStr2intVec& IntFeatureData,
     GErrorStr += "\nError: At least than 3 spikes are needed for burst calculation.\n";
     return -1;
   }
-  retVal = getDoubleParam(DoubleFeatureData, "burst_factor", tVec);
+  retVal = getDoubleParam(DoubleFeatureData, "strict_burst_factor", tVec);
   if (retVal < 0)
     burst_factor = 2;
   else

--- a/efel/cppcore/LibV5.h
+++ b/efel/cppcore/LibV5.h
@@ -260,5 +260,20 @@ int min_between_peaks_values(mapStr2intVec& IntFeatureData,
 int AP_width_between_threshold(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData);
+int burst_begin_indices(mapStr2intVec& IntFeatureData,
+                            mapStr2doubleVec& DoubleFeatureData,
+                            mapStr2Str& StringData);
+int burst_end_indices(mapStr2intVec& IntFeatureData,
+                            mapStr2doubleVec& DoubleFeatureData,
+                            mapStr2Str& StringData);
+int strict_burst_mean_freq(mapStr2intVec& IntFeatureData,
+                            mapStr2doubleVec& DoubleFeatureData,
+                            mapStr2Str& StringData);
+int strict_burst_number(mapStr2intVec& IntFeatureData,
+                            mapStr2doubleVec& DoubleFeatureData,
+                            mapStr2Str& StringData);
+int strict_interburst_voltage(mapStr2intVec& IntFeatureData,
+                            mapStr2doubleVec& DoubleFeatureData,
+                            mapStr2Str& StringData);
 }
 #endif

--- a/efel/cppcore/cfeature.cpp
+++ b/efel/cppcore/cfeature.cpp
@@ -251,6 +251,12 @@ void cFeature::fillfeaturetypes() {
   featuretypes["min_between_peaks_values"] = "double";
   featuretypes["AP_width_between_threshold"] = "double";
 
+  featuretypes["burst_begin_indices"] = "int";
+  featuretypes["burst_end_indices"] = "int";
+  featuretypes["strict_burst_mean_freq"] = "double";
+  featuretypes["strict_burst_number"] = "int";
+  featuretypes["strict_interburst_voltage"] = "double";
+
   // end of feature types
 }
 

--- a/efel/tests/featurenames.json
+++ b/efel/tests/featurenames.json
@@ -166,5 +166,10 @@
     "voltage_deflection_vb_ssse",
     "min_between_peaks_indices",
     "min_between_peaks_values",
-    "AP_width_between_threshold"
+    "AP_width_between_threshold",
+    "burst_begin_indices",
+    "burst_end_indices",
+    "strict_burst_number",
+    "strict_burst_mean_freq",
+    "strict_interburst_voltage"
 ]

--- a/efel/tests/testdata/allfeatures/expectedresults.json
+++ b/efel/tests/testdata/allfeatures/expectedresults.json
@@ -377,15 +377,10 @@
     "amp_drop_second_last": [
         4.787221503925529
     ],
-    "burst_ISI_indices": [
-        3
-    ],
-    "burst_mean_freq": [
-        3.9840637450221186,
-        7.990411506199836
-    ],
+    "burst_ISI_indices": [],
+    "burst_mean_freq": [],
     "burst_number": [
-        2
+        0
     ],
     "check_AISInitiation": [
         1.0
@@ -416,9 +411,7 @@
         -2.3296693271049533,
         -2.3944223175083863
     ],
-    "interburst_voltage": [
-        -38.820613862535545
-    ],
+    "interburst_voltage": [],
     "inv_fifth_ISI": [
         3.995205753099918
     ],
@@ -60633,5 +60626,23 @@
         2.9999999999972715,
         3.2999999999969987,
         3.2999999999969987
+    ],
+    "burst_begin_indices": [
+        0,
+        4
+    ],
+    "burst_end_indices": [
+        1,
+        5
+    ],
+    "strict_burst_number": [
+        2
+    ],
+    "strict_burst_mean_freq": [
+        9.83767831,
+        7.99041151
+    ],
+    "strict_interburst_voltage": [
+        -38.82061386
     ]
 }

--- a/efel/tests/testdata/allfeatures/expectedresults.json
+++ b/efel/tests/testdata/allfeatures/expectedresults.json
@@ -377,10 +377,15 @@
     "amp_drop_second_last": [
         4.787221503925529
     ],
-    "burst_ISI_indices": [],
-    "burst_mean_freq": [],
+    "burst_ISI_indices": [
+        3
+    ],
+    "burst_mean_freq": [
+        3.9840637450221186,
+        7.990411506199836
+    ],
     "burst_number": [
-        0
+        2
     ],
     "check_AISInitiation": [
         1.0
@@ -411,7 +416,9 @@
         -2.3296693271049533,
         -2.3944223175083863
     ],
-    "interburst_voltage": [],
+    "interburst_voltage": [
+        -38.820613862535545
+    ],
     "inv_fifth_ISI": [
         3.995205753099918
     ],


### PR DESCRIPTION
This new implementation does not assume that every spike belongs to a burst. With it, we know at which peak index each burst begins and ends. This avoids to integrate isolated spikes in bursts. 
It takes into account the first spike.
This new implementation is sensitive to `burst_factor`, so I changed the default value of burst_factor to `2`, in order to avoid removing spikes from bursts, although they should remain in them.

New features use this implementation:  `strict_burst_number`, `strict_burst_mean_freq`, `strict_interburst_voltage`

Also added corresponding tests and doc.

This is a possible solution to Issue #249