### PR TITLE
replace ubuntu-latest by ubuntu-20.04 in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         python: [cp36, cp37, cp38, cp39, cp310]
         arch: [x86_64, amd64, 32]
         exclude:
@@ -26,9 +26,9 @@ jobs:
             arch: amd64
           - os: macos-latest
             arch: 32
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             arch: amd64
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             arch: 32
           - os: windows-latest
             arch: x86_64
@@ -61,7 +61,7 @@ jobs:
   
   tarball:
     name: Build tarball
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: call-test-workflow
     steps:
       - uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
 
   publish:
     name: Publish on PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [call-test-workflow, wheels, tarball]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -11,7 +11,7 @@ jobs:
   
   keep-workflow-alive:
     name: Keep workflow alive
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]


### PR DESCRIPTION
It looks like ubuntu-latest was upgraded recently from 20.04 to 22.04 and that makes our workflow fail at the Set Up Python step.
This PR solves this by using ubuntu 20.04 instead of latest