### PR TITLE
remove windows32 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,22 +20,15 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
         python: [cp36, cp37, cp38, cp39, cp310]
-        arch: [x86_64, amd64, 32]
+        arch: [x86_64, amd64]
         exclude:
           - os: macos-latest
             arch: amd64
-          - os: macos-latest
-            arch: 32
           - os: ubuntu-20.04
             arch: amd64
-          - os: ubuntu-20.04
-            arch: 32
           - os: windows-latest
             arch: x86_64
-          # dropping support for windows 32bit for python >=3.10
-          - os: windows-latest
-            arch: 32
-            python: cp310
+
     env:
       CIBW_BUILD: ${{ matrix.python }}*${{ matrix.arch }}
       CIBW_TEST_REQUIRES: pytest neo[neomatlabio]>=0.5.1


### PR DESCRIPTION
We need scipy for testing our wheels, and our ci pipelines fail at the building scipy phase for some of our windows 32-bit wheels.
We already dropped our support for python3.10 on windows 32. I propose here that we stop building wheels for windows-32 altogether.