### PR TITLE
Only take into account data after stim_start in AP_width

### DIFF
--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -848,7 +848,7 @@ LibV1 : AP_width
 
 Width of spike at threshold, bounded by minimum AHP
 
-Can use strict_stiminterval to not use minimum after stimulus end.
+Can use strict_stiminterval compute only for data in stimulus interval.
 
 - **Required features**: LibV1: peak_indices, LibV5: min_AHP_indices, threshold
 - **Units**: ms

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -1796,9 +1796,10 @@ int LibV1::printVectorD(char* strName, vector<double> vec) {
 // unfortunately spike width means the width of the spike on onset not at half
 // maximum
 static int __AP_width(const vector<double>& t, const vector<double>& v,
-                      double stimstart, double threshold,
+                      double stimstart, double stimend, double threshold,
                       const vector<int>& peakindices,
                       const vector<int>& minahpindices,
+                      const bool strict_stiminterval,
                       vector<double>& apwidth) {
   //   printf("\n Inside AP_width...\n");
   //   printVectorD("t", t);
@@ -1807,12 +1808,23 @@ static int __AP_width(const vector<double>& t, const vector<double>& v,
   //   printVectorI("minahpindices", minahpindices);
   //   printf("\nStimStart = %f , thereshold = %f ", stimstart, threshold);
   vector<int> indices;
-  int start_index = distance(
-      t.begin(),
-      find_if(t.begin(), t.end(), bind2nd(greater_equal<double>(), stimstart)));
-  indices.push_back(start_index);
-  for (size_t i = 0; i < minahpindices.size(); i++) {
-    if (minahpindices[i] > start_index) {
+  if (strict_stiminterval){
+    int start_index = distance(
+        t.begin(),
+        find_if(t.begin(), t.end(), bind2nd(greater_equal<double>(), stimstart)));
+    int end_index =
+        distance(t.begin(),
+                 find_if(t.begin(), t.end(),
+                         std::bind2nd(std::greater_equal<double>(), stimend)));
+    indices.push_back(start_index);
+    for (size_t i = 0; i < minahpindices.size(); i++) {
+      if (start_index < minahpindices[i] && minahpindices[i] < end_index) {
+        indices.push_back(minahpindices[i]);
+      }
+    }
+  } else {
+    indices.push_back(0);
+    for (size_t i = 0; i < minahpindices.size(); i++) {
       indices.push_back(minahpindices[i]);
     }
   }
@@ -1864,6 +1876,9 @@ int LibV1::AP_width(mapStr2intVec& IntFeatureData,
   vector<double> stimstart;
   retval = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
   if (retval < 0) return -1;
+  vector<double> stimend;
+  retval = getVec(DoubleFeatureData, StringData, "stim_end", stimend);
+  if (retval < 0) return -1;
   vector<int> peakindices;
   retval = getVec(IntFeatureData, StringData, "peak_indices", peakindices);
   if (retval <= 0) {
@@ -1874,9 +1889,18 @@ int LibV1::AP_width(mapStr2intVec& IntFeatureData,
   vector<int> minahpindices;
   retval = getVec(IntFeatureData, StringData, "min_AHP_indices", minahpindices);
   if (retval < 0) return -1;
+  bool strict_stiminterval;
+  vector<int> strict_stiminterval_vec;
+  retval = getIntParam(IntFeatureData, "strict_stiminterval",
+                       strict_stiminterval_vec);
+  if (retval <= 0) {
+    strict_stiminterval = false;
+  } else {
+    strict_stiminterval = bool(strict_stiminterval_vec[0]);
+  }
   vector<double> apwidth;
-  retval = __AP_width(t, v, stimstart[0], threshold[0], peakindices,
-                      minahpindices, apwidth);
+  retval = __AP_width(t, v, stimstart[0], stimend[0], threshold[0], peakindices,
+                      minahpindices, strict_stiminterval, apwidth);
   if (retval >= 0) {
     setVec(DoubleFeatureData, StringData, "AP_width", apwidth);
   }

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -1806,12 +1806,16 @@ static int __AP_width(const vector<double>& t, const vector<double>& v,
   //   printVectorI("peakindices", peakindices);
   //   printVectorI("minahpindices", minahpindices);
   //   printf("\nStimStart = %f , thereshold = %f ", stimstart, threshold);
-  vector<int> indices(minahpindices.size() + 1);
+  vector<int> indices;
   int start_index = distance(
       t.begin(),
       find_if(t.begin(), t.end(), bind2nd(greater_equal<double>(), stimstart)));
-  indices[0] = start_index;
-  copy(minahpindices.begin(), minahpindices.end(), indices.begin() + 1);
+  indices.push_back(start_index);
+  for (size_t i = 0; i < minahpindices.size(); i++) {
+    if (minahpindices[i] > start_index) {
+      indices.push_back(minahpindices[i]);
+    }
+  }
   for (size_t i = 0; i < indices.size() - 1; i++) {
     /*
     // FWHM (not used):

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -3408,4 +3408,14 @@ def test_AP_width_spike_before_stim_start():
 
     ap_width = feature_values[0]['AP_width']
 
-    assert len(ap_width) == 14
+    assert len(ap_width) == 15
+
+    efel.setIntSetting('strict_stiminterval', 1)
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features)
+
+    ap_width = feature_values[0]['AP_width']
+
+    assert len(ap_width) == 13

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -3379,3 +3379,33 @@ def test_strict_interburst_voltage():
         strict_interburst_voltage, strict_interburst_voltage_py
     )
     numpy.testing.assert_allclose(strict_interburst_voltage, -63.234682)
+
+
+def test_AP_width_spike_before_stim_start():
+    """basic: Test AP_width with a spike before stim start"""
+    import efel
+    efel.reset()
+
+    stim_start = 700.0
+    stim_end = 2700.0
+
+    time = efel.io.load_fragment('%s#col=1' % spikeoutsidestim_url)
+    voltage = efel.io.load_fragment('%s#col=2' % spikeoutsidestim_url)
+
+    trace = {}
+
+    trace['T'] = time
+    trace['V'] = voltage
+    trace['stim_start'] = [stim_start]
+    trace['stim_end'] = [stim_end]
+
+    features = ['AP_width']
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features)
+
+    ap_width = feature_values[0]['AP_width']
+
+    assert len(ap_width) == 14


### PR DESCRIPTION
We used to search for data between `stim_start` index and spike index for `AP_width` feature for all spike indices. When we had a spike before `stim_start`, this was prone to `Segmentation Fault` error (especially when there was no other spike AFTER stim_start).

I solved this by removing indices of any spikes before `stim_start` in `AP_width`.