### PR TITLE
fix interpolation for edge case where stop % step == 0

### DIFF
--- a/efel/cppcore/Utils.cpp
+++ b/efel/cppcore/Utils.cpp
@@ -38,7 +38,7 @@ int LinearInterpolation(double Stepdx,
   size_t InterpX_size;
   double x = X[0];
   double start = X[0];
-  double stop = X[X.size() - 1] + Stepdx;
+  double stop = X[X.size() - 1];
   
   // Inspired by the way numpy.arange works
   // Do not remove the 'ceil' in favor of < stop in for loop
@@ -47,6 +47,11 @@ int LinearInterpolation(double Stepdx,
   for (size_t i = 0; i < InterpX_size; i++) {
       InterpX.push_back(x);
       x += Stepdx;
+  }
+
+  if (InterpX[InterpX.size() - 1] < X[X.size() - 1]){
+    InterpX.push_back(x);
+    InterpX_size += 1;
   }
 
   // Create the y values


### PR DESCRIPTION
Solves issue #268

Explanation:
We used to stop at last time value + interpolation step.
When interpolation step is such that the last two interpolated time values are above the last non-interpolation time value, the interpolation breaks and doesn't add a final voltage interpolated value. This can happen or not depending on float precision/rounding, which makes it difficult to manage. (e.g. breaks for step=0.05, but works for step=0.1)
Instead of stopping at last time value + interpolation step for any step, I stop at last time value, and add a supplementary interpolated value only if last interpolated value < last non-interpolated value.