### PR TITLE
Add AHP_depth_slow feature

### DIFF
--- a/docs/source/developers.rst
+++ b/docs/source/developers.rst
@@ -95,7 +95,7 @@ Then, while you are implementing the code in C++ you can easily compare the
 results to the Nose test.
 
 The Nose tests of the individual eFeatures are
-`here <https://github.com/BlueBrain/eFEL/blob/master/efel/tests/
+`here_nose <https://github.com/BlueBrain/eFEL/blob/master/efel/tests/
 test_basic.py>`_
 .Just add your own test by defining a new function 'test_yourfeature()'.
 

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -724,6 +724,21 @@ a given number of ms (default: 5) after the peak
 - **Required features**: LibV1:peak_indices
 - **Units**: mV
 
+
+LibV1 : AHP_depth_slow
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+Relative voltage values at the first after-hyperpolarization starting 
+a given number of ms (default: 5) after the peak
+
+- **Required features**: LibV1:voltage_base (mV), LibV1:AHP_depth_abs_slow (mV)
+- **Units**: mV
+- **Pseudocode**: ::
+
+    AHP_depth_slow = AHP_depth_abs_slow[:] - voltage_base
+
+
 LibV1 : AHP_slow_time
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -724,10 +724,8 @@ a given number of ms (default: 5) after the peak
 - **Required features**: LibV1:peak_indices
 - **Units**: mV
 
-
 LibV1 : AHP_depth_slow
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+~~~~~~~~~~~~~~~~~~~~~~
 
 Relative voltage values at the first after-hyperpolarization starting 
 a given number of ms (default: 5) after the peak
@@ -737,7 +735,6 @@ a given number of ms (default: 5) after the peak
 - **Pseudocode**: ::
 
     AHP_depth_slow = AHP_depth_abs_slow[:] - voltage_base
-
 
 LibV1 : AHP_slow_time
 ~~~~~~~~~~~~~~~~~~~~~

--- a/efel/DependencyV5.txt
+++ b/efel/DependencyV5.txt
@@ -32,7 +32,7 @@ LibV1:ISI_CV	#LibV1:ISI_values #LibV1:interpolate
 LibV1:Spikecount	#LibV5:peak_indices #LibV1:interpolate 
 LibV5:Spikecount_stimint	#LibV1:peak_time #LibV1:interpolate 
 LibV1:AHP_depth	#LibV5:voltage_base	#LibV5:min_AHP_values #LibV1:interpolate 
-LibV1:AHP_depth_slow    #LibV5:voltage_base	#LibV5:min_AHP_values #LibV1:interpolate
+LibV1:AHP_depth_slow    #LibV5:voltage_base	#LibV1:AHP_depth_abs_slow #LibV1:interpolate
 LibV2:AP_rise_indices       #LibV5:peak_indices     #LibV5:AP_begin_indices #LibV1:interpolate
 LibV5:AP_end_indices        #LibV5:peak_indices #LibV1:interpolate
 LibV2:AP_fall_indices       #LibV5:peak_indices     #LibV5:AP_begin_indices     #LibV5:AP_end_indices #LibV1:interpolate 

--- a/efel/DependencyV5.txt
+++ b/efel/DependencyV5.txt
@@ -32,7 +32,7 @@ LibV1:ISI_CV	#LibV1:ISI_values #LibV1:interpolate
 LibV1:Spikecount	#LibV5:peak_indices #LibV1:interpolate 
 LibV5:Spikecount_stimint	#LibV1:peak_time #LibV1:interpolate 
 LibV1:AHP_depth	#LibV5:voltage_base	#LibV5:min_AHP_values #LibV1:interpolate 
-LibV1:AHP_depth_slow	#LibV5:voltage_base	#LibV5:min_AHP_values #LibV1:interpolate 
+LibV1:AHP_depth_slow    #LibV5:voltage_base	#LibV5:min_AHP_values #LibV1:interpolate
 LibV2:AP_rise_indices       #LibV5:peak_indices     #LibV5:AP_begin_indices #LibV1:interpolate
 LibV5:AP_end_indices        #LibV5:peak_indices #LibV1:interpolate
 LibV2:AP_fall_indices       #LibV5:peak_indices     #LibV5:AP_begin_indices     #LibV5:AP_end_indices #LibV1:interpolate 

--- a/efel/DependencyV5.txt
+++ b/efel/DependencyV5.txt
@@ -32,6 +32,7 @@ LibV1:ISI_CV	#LibV1:ISI_values #LibV1:interpolate
 LibV1:Spikecount	#LibV5:peak_indices #LibV1:interpolate 
 LibV5:Spikecount_stimint	#LibV1:peak_time #LibV1:interpolate 
 LibV1:AHP_depth	#LibV5:voltage_base	#LibV5:min_AHP_values #LibV1:interpolate 
+LibV1:AHP_depth_slow	#LibV5:voltage_base	#LibV5:min_AHP_values #LibV1:interpolate 
 LibV2:AP_rise_indices       #LibV5:peak_indices     #LibV5:AP_begin_indices #LibV1:interpolate
 LibV5:AP_end_indices        #LibV5:peak_indices #LibV1:interpolate
 LibV2:AP_fall_indices       #LibV5:peak_indices     #LibV5:AP_begin_indices     #LibV5:AP_end_indices #LibV1:interpolate 

--- a/efel/cppcore/FillFptrTable.cpp
+++ b/efel/cppcore/FillFptrTable.cpp
@@ -56,6 +56,7 @@ int FillFptrTable() {
   FptrTableV1["AHP_slow_time"] = &LibV1::AHP_slow_time;
   FptrTableV1["Spikecount"] = &LibV1::Spikecount;
   FptrTableV1["AHP_depth"] = &LibV1::AHP_depth;
+  FptrTableV1["AHP_depth_slow"] = &LibV1::AHP_depth_slow;
   FptrTableV1["burst_number"] = &LibV1::burst_number;
   FptrTableV1["AP_amplitude_diff"] = &LibV1::AP_amplitude_diff;
   FptrTableV1["AHP_depth_diff"] = &LibV1::AHP_depth_diff;

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -1934,6 +1934,44 @@ int LibV1::doublet_ISI(mapStr2intVec& IntFeatureData,
 }
 // end of doublet_ISI
 
+// *** AHP_depth_slow ***
+static int __AHP_depth_slow(const vector<double>& voltagebase,
+                       const vector<double>& minahpvalues,
+                       vector<double>& ahpdepth) {
+  for (size_t i = 0; i < minahpvalues.size(); i++) {
+    ahpdepth.push_back(minahpvalues[i] - voltagebase[0]);
+  }
+  return ahpdepth.size();
+}
+int LibV1::AHP_depth_slow(mapStr2intVec& IntFeatureData,
+                     mapStr2doubleVec& DoubleFeatureData,
+                     mapStr2Str& StringData) {
+  int retval;
+  int nsize;
+  retval = CheckInMap(DoubleFeatureData, StringData, "AHP_depth", nsize);
+  if (retval) {
+    return nsize;
+  }
+
+  vector<double> voltagebase;
+  retval = getVec(DoubleFeatureData, StringData, "voltage_base",
+                        voltagebase);
+  if (retval < 0) return -1;
+  vector<double> minahpvalues;
+  retval = getVec(DoubleFeatureData, StringData, "AHP_depth_abs_slow",
+                        minahpvalues);
+  if (retval < 0) return -1;
+
+  vector<double> ahpdepth;
+  retval = __AHP_depth_slow(voltagebase, minahpvalues, ahpdepth);
+  if (retval >= 0) {
+    setVec(DoubleFeatureData, StringData, "AHP_depth", ahpdepth);
+  }
+  return retval;
+}
+// end of AHP_depth_slow
+
+
 // *** AHP_depth ***
 static int __AHP_depth(const vector<double>& voltagebase,
                        const vector<double>& minahpvalues,

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -1943,12 +1943,13 @@ static int __AHP_depth_slow(const vector<double>& voltagebase,
   }
   return ahpdepth.size();
 }
+
 int LibV1::AHP_depth_slow(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
   int retval;
   int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "AHP_depth", nsize);
+  retval = CheckInMap(DoubleFeatureData, StringData, "AHP_depth_slow", nsize);
   if (retval) {
     return nsize;
   }
@@ -1957,15 +1958,16 @@ int LibV1::AHP_depth_slow(mapStr2intVec& IntFeatureData,
   retval = getVec(DoubleFeatureData, StringData, "voltage_base",
                         voltagebase);
   if (retval < 0) return -1;
-  vector<double> minahpvalues;
+  vector<double> ahpdepthabsslow;
   retval = getVec(DoubleFeatureData, StringData, "AHP_depth_abs_slow",
-                        minahpvalues);
+                        ahpdepthabsslow);
+  std::cout << "retval:" << retval;
   if (retval < 0) return -1;
 
-  vector<double> ahpdepth;
-  retval = __AHP_depth_slow(voltagebase, minahpvalues, ahpdepth);
+  vector<double> ahpdepthslow;
+  retval = __AHP_depth_slow(voltagebase, ahpdepthabsslow, ahpdepthslow);
   if (retval >= 0) {
-    setVec(DoubleFeatureData, StringData, "AHP_depth", ahpdepth);
+    setVec(DoubleFeatureData, StringData, "AHP_depth_slow", ahpdepthslow);
   }
   return retval;
 }

--- a/efel/cppcore/LibV1.h
+++ b/efel/cppcore/LibV1.h
@@ -143,6 +143,9 @@ int Spikecount(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData);
 int AHP_depth(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData);
+int AHP_depth_slow(mapStr2intVec& IntFeatureData,
+                       mapStr2doubleVec& DoubleFeatureData,
+                       mapStr2Str& StringData);
 int burst_number(mapStr2intVec& IntFeatureData,
                  mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData);
 int AP_amplitude_diff(mapStr2intVec& IntFeatureData,

--- a/efel/cppcore/cfeature.cpp
+++ b/efel/cppcore/cfeature.cpp
@@ -165,6 +165,7 @@ void cFeature::fillfeaturetypes() {
   featuretypes["Spikecount"] = "int";
   featuretypes["Spikecount_stimint"] = "int";
   featuretypes["AHP_depth"] = "double";
+  featuretypes["AHP_depth_slow"] = "double";
   featuretypes["amp_drop_first_second"] = "double";
   featuretypes["amp_drop_first_last"] = "double";
   featuretypes["amp_drop_second_last"] = "double";

--- a/efel/pyfeatures/pyfeatures.py
+++ b/efel/pyfeatures/pyfeatures.py
@@ -101,6 +101,7 @@ def initburst_sahp():
     # Required cpp features
     voltage = _get_cpp_feature("voltage")
     time = _get_cpp_feature("time")
+    time = time[:len(voltage)]
     peak_times = _get_cpp_feature("peak_time")
 
     # Required python features

--- a/efel/tests/featurenames.json
+++ b/efel/tests/featurenames.json
@@ -178,5 +178,6 @@
     "ADP_peak_amplitude",
     "interburst_min_indices",
     "interburst_min_values",
-    "time_to_interburst_min"
+    "time_to_interburst_min",
+    "AHP_depth_slow"
 ]

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -3149,6 +3149,33 @@ def test_AHP_depth_diff():
     )
 
 
+def test_AHP_depth_slow():
+    """basic: Test AHP depth slow"""
+
+    import efel
+    efel.reset()
+
+    trace, time, voltage, stim_start, stim_end = load_data(
+        'mean_frequency1', interp=True)
+
+    features = ["AHP_depth_slow", "AHP_depth_abs_slow", "voltage_base"]
+
+    feature_values = \
+        efel.getFeatureValues(
+            [trace],
+            features, raise_warnings=False)
+
+    AHP_depth_slow = feature_values[0]["AHP_depth_slow"]
+    AHP_depth_abs_slow = feature_values[0]["AHP_depth_abs_slow"]
+    voltage_base = feature_values[0]["voltage_base"]
+
+    expected = AHP_depth_abs_slow - voltage_base
+
+    numpy.testing.assert_allclose(
+        AHP_depth_slow, expected
+    )
+
+
 def test_mean_AP_amplitude():
     """basic: Test mean AP amplitude"""
 

--- a/efel/tests/testdata/allfeatures/expectedresults.json
+++ b/efel/tests/testdata/allfeatures/expectedresults.json
@@ -60674,5 +60674,11 @@
     ],
     "interburst_min_indices": [],
     "interburst_min_values": [],
-    "time_to_interburst_min": []
+    "time_to_interburst_min": [],
+    "AHP_depth_slow":[
+        28.81047723194662,
+        32.02907786238346,
+        32.65404519917785,
+        33.435288866699345
+    ]
 }


### PR DESCRIPTION
This feature prevents bias of AHP depth due to spurious effect right after AP, see for example red trace here:
![ahp](https://user-images.githubusercontent.com/12429955/223467883-d2ff0a7a-765f-4035-93d5-9c1288dd2c76.png)

