### PR TITLE
new feature: postburst_min_values

### DIFF
--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -502,6 +502,36 @@ The first spike is ignored by default. This can be changed by setting ignore_fir
         ) for i in burst_end_indices if i + 1 < len(peak_indices)
     ]
 
+LibV5 : postburst_min_values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The minimum voltage after the end of a burst.
+
+This implementation does not assume that every spike belongs to a burst.
+
+The first spike is ignored by default. This can be changed by setting ignore_first_ISI to 0.
+
+- **Required features**: peak_indices, burst_end_indices
+- **Units**: mV
+- **Pseudocode**: ::
+
+    interburst_min = [
+        numpy.min(
+            v[peak_indices[i]:peak_indices[i + 1]]
+        ) for i in burst_end_indices if i + 1 < len(peak_indices)
+    ]
+
+    if len(postburst_min) < len(burst_end_indices):
+        if t[burst_end_indices[-1]] < stim_end:
+            end_idx = numpy.where(t >= stim_end)[0][0]
+            postburst_min.append(numpy.min(
+                v[peak_indices[burst_end_indices[-1]]:peak_indices[end_idx]]
+            ))
+        else:
+            postburst_min.append(numpy.min(
+                v[peak_indices[burst_end_indices[-1]]:]
+            ))
+
 LibV5 : time_to_interburst_min
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -525,7 +525,7 @@ The first spike is ignored by default. This can be changed by setting ignore_fir
         if t[burst_end_indices[-1]] < stim_end:
             end_idx = numpy.where(t >= stim_end)[0][0]
             postburst_min.append(numpy.min(
-                v[peak_indices[burst_end_indices[-1]]:peak_indices[end_idx]]
+                v[peak_indices[burst_end_indices[-1]]:end_idx]
             ))
         else:
             postburst_min.append(numpy.min(

--- a/efel/DependencyV5.txt
+++ b/efel/DependencyV5.txt
@@ -172,4 +172,6 @@ LibV5:ADP_peak_values     #LibV5:ADP_peak_indices #LibV1:interpolate
 LibV5:ADP_peak_amplitude  #LibV5:ADP_peak_values #LibV5:min_AHP_values #LibV1:interpolate
 LibV5:interburst_min_indices     #LibV5:peak_indices #LibV5:burst_end_indices #LibV1:interpolate
 LibV5:interburst_min_values      #LibV5:interburst_min_indices #LibV1: interpolate
+LibV5:postburst_min_indices     #LibV5:peak_indices #LibV5:burst_end_indices #LibV1:interpolate
+LibV5:postburst_min_values      #LibV5:postburst_min_indices #LibV1: interpolate
 LibV5:time_to_interburst_min     #LibV5:interburst_min_indices #LibV1:peak_time #LibV5:burst_end_indices #LibV1:interpolate

--- a/efel/cppcore/FillFptrTable.cpp
+++ b/efel/cppcore/FillFptrTable.cpp
@@ -285,6 +285,8 @@ int FillFptrTable() {
 
   FptrTableV5["interburst_min_indices"] = &LibV5::interburst_min_indices;
   FptrTableV5["interburst_min_values"] = &LibV5::interburst_min_values;
+  FptrTableV5["postburst_min_indices"] = &LibV5::postburst_min_indices;
+  FptrTableV5["postburst_min_values"] = &LibV5::postburst_min_values;
   FptrTableV5["time_to_interburst_min"] = &LibV5::time_to_interburst_min;
   
   //****************** end of FptrTableV5 *****************************

--- a/efel/cppcore/LibV5.h
+++ b/efel/cppcore/LibV5.h
@@ -290,6 +290,12 @@ int interburst_min_indices(mapStr2intVec& IntFeatureData,
 int interburst_min_values(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData);
+int postburst_min_indices(mapStr2intVec& IntFeatureData,
+                            mapStr2doubleVec& DoubleFeatureData,
+                            mapStr2Str& StringData);
+int postburst_min_values(mapStr2intVec& IntFeatureData,
+                            mapStr2doubleVec& DoubleFeatureData,
+                            mapStr2Str& StringData);
 int time_to_interburst_min(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData);

--- a/efel/cppcore/cfeature.cpp
+++ b/efel/cppcore/cfeature.cpp
@@ -264,6 +264,8 @@ void cFeature::fillfeaturetypes() {
 
   featuretypes["interburst_min_indices"] = "int";
   featuretypes["interburst_min_values"] = "double";
+  featuretypes["postburst_min_indices"] = "int";
+  featuretypes["postburst_min_values"] = "double";
   featuretypes["time_to_interburst_min"] = "double";
 
   // end of feature types

--- a/efel/tests/featurenames.json
+++ b/efel/tests/featurenames.json
@@ -181,6 +181,8 @@
     "ADP_peak_amplitude",
     "interburst_min_indices",
     "interburst_min_values",
+    "postburst_min_indices",
+    "postburst_min_values",
     "time_to_interburst_min",
     "AHP_depth_slow"
 ]

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -3662,7 +3662,7 @@ def py_postburst_min_values(t, v, peak_indices, burst_end_indices, stim_end):
         if t[burst_end_indices[-1]] < stim_end:
             end_idx = numpy.where(t >= stim_end)[0][0]
             postburst_min.append(numpy.min(
-                v[peak_indices[burst_end_indices[-1]]:peak_indices[end_idx]]
+                v[peak_indices[burst_end_indices[-1]]:end_idx]
             ))
         else:
             postburst_min.append(numpy.min(

--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -3648,6 +3648,91 @@ def test_time_to_interburst_min():
         )
 
 
+def py_postburst_min_values(t, v, peak_indices, burst_end_indices, stim_end):
+    """min voltage between burst and next peak"""
+    if peak_indices is None or burst_end_indices is None:
+        return None
+
+    postburst_min = [
+        numpy.min(
+            v[peak_indices[i]:peak_indices[i + 1]]
+        ) for i in burst_end_indices if i + 1 < len(peak_indices)
+    ]
+    if len(postburst_min) < len(burst_end_indices):
+        if t[burst_end_indices[-1]] < stim_end:
+            end_idx = numpy.where(t >= stim_end)[0][0]
+            postburst_min.append(numpy.min(
+                v[peak_indices[burst_end_indices[-1]]:peak_indices[end_idx]]
+            ))
+        else:
+            postburst_min.append(numpy.min(
+                v[peak_indices[burst_end_indices[-1]]:]
+            ))
+
+    return numpy.array(postburst_min)
+
+
+def test_postburst_min_values():
+    """basic: Test interburst_min_values"""
+    urls = [burst1_url, burst2_url, burst3_url]
+    for i, url in enumerate(urls):
+        import efel
+        efel.reset()
+        # use this to have all spikes in burst for burst3_url case
+        efel.setDoubleSetting('strict_burst_factor', 4.0)
+
+        time = efel.io.load_fragment('%s#col=1' % url)
+        voltage = efel.io.load_fragment('%s#col=2' % url)
+
+        interp_time, interp_voltage = interpolate(time, voltage, 0.1)
+
+        trace = {}
+
+        trace['T'] = time
+        trace['V'] = voltage
+        if i in [0, 1]:
+            trace['stim_start'] = [250]
+            trace['stim_end'] = [1600]
+        elif i == 2:
+            trace['stim_start'] = [800]
+            trace['stim_end'] = [2150]
+
+        features = [
+            "peak_indices",
+            "burst_end_indices",
+            "postburst_min_values",
+        ]
+
+        feature_values = efel.getFeatureValues(
+            [trace],
+            features,
+            raise_warnings=False
+        )
+
+        peak_indices = feature_values[0]["peak_indices"]
+        burst_end_indices = feature_values[0]["burst_end_indices"]
+        postburst_min_values = feature_values[0]["postburst_min_values"]
+
+        postburst_min_py = py_postburst_min_values(
+            interp_time,
+            interp_voltage,
+            peak_indices,
+            burst_end_indices,
+            trace["stim_end"][0]
+        )
+
+        # convert to float so that None edge case get converted to nan
+        # and can pass in assert_allclose
+        postburst_min_py = numpy.array(postburst_min_py, dtype=numpy.float64)
+        postburst_min_values = numpy.array(
+            postburst_min_values, dtype=numpy.float64
+        )
+
+        numpy.testing.assert_allclose(
+            postburst_min_py, postburst_min_values
+        )
+
+
 def test_spikes_per_burst_diff():
     """basic: Test spikes_per_burst_diff"""
     import efel

--- a/efel/tests/testdata/allfeatures/expectedresults.json
+++ b/efel/tests/testdata/allfeatures/expectedresults.json
@@ -60679,6 +60679,12 @@
     ],
     "interburst_min_indices": [],
     "interburst_min_values": [],
+    "postburst_min_indices": [
+        26465
+    ],
+    "postburst_min_values": [
+        -41.52919675004766
+    ],
     "time_to_interburst_min": [],
     "AHP_depth_slow": [
         28.81047723194662,


### PR DESCRIPTION
similar to interburst_min_values, but also gives a value after the last burst, even when there is no spike after it.