### PR TITLE
fix AP_begin_indices

### DIFF
--- a/efel/tests/test_basic.py
+++ b/efel/tests/test_basic.py
@@ -1348,7 +1348,7 @@ def test_derivwindow1():
             features)
 
     AP_begin_voltage = feature_values[0]['AP_begin_voltage'][0]
-    numpy.testing.assert_allclose(AP_begin_voltage, -83.57661997973835)
+    numpy.testing.assert_allclose(AP_begin_voltage, -45.5055215)
 
     efel.reset()
     efel.setDoubleSetting('interp_step', 0.01)


### PR DESCRIPTION
Should fix issues #278 and #279 .

Basically, instead of searching for AP_begin from start index (either stim start index, or min ahp index) to peak index, we do the inverse: we search from peak index to start index. Since in both cases we keep the 1st match we find, the new version is better because we avoid all the 'false positives' we can encounter around stim start time.

So this is more resilient to false positives.

However, let's consider a case where the derivative goes above threshold, then slightly below, then above again.
When using the new version of AP_begin_indices, we would only keep the value when we go above the 2nd time.