### PR TITLE
fix AP_begin

### DIFF
--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -657,7 +657,7 @@ static int __AP_begin_indices(const vector<double>& t, const vector<double>& v,
   minima.push_back(endindex);
   //}
   // printf("Found %d minima\n", minima.size());
-  for (size_t i = 0; i < minima.size() - 1; i++) {
+  for (size_t i = 0; i < minima.size() - 2; i++) {
     // assure that the width of the slope is bigger than 4
     int newbegin = minima[i + 1];
     int begin = minima[i];
@@ -675,6 +675,10 @@ static int __AP_begin_indices(const vector<double>& t, const vector<double>& v,
               dvdt.rbegin() + v.size() - newbegin,
               dvdt.rbegin() + v.size() - minima[i],
               std::bind2nd(std::less_equal<double>(), derivativethreshold)).base());
+      // cover edge case to avoid going out of index in the while condition
+      if (begin > endindex - width){
+        begin = endindex - width;
+      }
       // printf("%d %d\n", newbegin, minima[i+1]);
       if (begin == minima[i]) {
         // printf("Skipping %d %d\n", newbegin, minima[i+1]);


### PR DESCRIPTION
This should avoid indexing out of bounds in AP_begin.

The old AP_begin feature would search for an AP_begin after the last spike. I think it does not make much sense, so I removed this last search.

Hopefully this will fix the segfaults we sometimes get during wheel building & testing.