### PR TITLE
Make AP_begin_indices depend on peak_indices

### DIFF
--- a/efel/DependencyV5.txt
+++ b/efel/DependencyV5.txt
@@ -119,7 +119,7 @@ LibV5:inv_fifth_ISI   #LibV5:all_ISI_values #LibV1:interpolate
 LibV5:inv_last_ISI   #LibV5:all_ISI_values #LibV1:interpolate 
 LibV5:inv_time_to_first_spike   #LibV1:time_to_first_spike #LibV1:interpolate 
 LibV5:spike_half_width 	    #LibV5:min_AHP_indices	#LibV5:peak_indices #LibV1:interpolate 
-LibV5:AP_begin_indices      #LibV5:min_AHP_indices #LibV1:interpolate
+LibV5:AP_begin_indices      #LibV5:min_AHP_indices #LibV5:peak_indices #LibV1:interpolate
 LibV5:AHP_depth_abs         #LibV5:min_AHP_values #LibV1:interpolate 
 LibV5:AP_begin_width 	    #LibV5:min_AHP_indices	#LibV5:AP_begin_indices #LibV1:interpolate 
 LibV5:AP_begin_voltage  #LibV5:AP_begin_indices #LibV1:interpolate 


### PR DESCRIPTION
Instead of searching for AP_begin_indices between two minima (min_AHP_indices), search for it between each peak and the minimum before it. (between stim_start and peak for 1st peak).

Solves error introduced by previous PR, which did not add the last AP_begin to the AP_begin_indices list, and thus made some features fail (AP_amplitude, etc.)