### PR TITLE
Edge case: first AP_begin exactly at stim_start

### DIFF
--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -643,8 +643,12 @@ static int __AP_begin_indices(const vector<double>& t, const vector<double>& v,
                find_if(t.begin(), t.end(),
                        std::bind2nd(std::greater_equal<double>(), stimstart)));
   
-  if (stimbeginindex > 0){
-    // to avoid skipping AP_begin when it is exactly at simbeginindex
+  if (stimbeginindex > 1){
+    // to avoid skipping AP_begin when it is exactly at stimbeginindex
+    // also because of float precision and interpolation, sometimes stimbeginindex
+    // can be slightly above 'real' stim begin index
+    minima.push_back(stimbeginindex - 2);
+  } else if (stimbeginindex == 1){
     minima.push_back(stimbeginindex - 1);
   } else {
     minima.push_back(stimbeginindex);

--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -642,7 +642,13 @@ static int __AP_begin_indices(const vector<double>& t, const vector<double>& v,
       distance(t.begin(),
                find_if(t.begin(), t.end(),
                        std::bind2nd(std::greater_equal<double>(), stimstart)));
-  minima.push_back(stimbeginindex);
+  
+  if (stimbeginindex > 0){
+    // to avoid skipping AP_begin when it is exactly at simbeginindex
+    minima.push_back(stimbeginindex - 1);
+  } else {
+    minima.push_back(stimbeginindex);
+  }
   for (size_t i = 0; i < ahpi.size(); i++) {
     if (ahpi[i] > stimbeginindex) {
       minima.push_back(ahpi[i]);


### PR DESCRIPTION
If possible, use stim_start_index - 1 instead of stim_start_index when looking for AP_begin to avoid skipping the first AP_begin for the edge case when it is exactly at stim_start_index.