### PR TITLE
add api to return features as a dataframe

### DIFF
--- a/efel/api.py
+++ b/efel/api.py
@@ -31,6 +31,7 @@ from __future__ import division
 
 import os
 import numpy
+import pandas as pd
 
 import efel
 import efel.cppcore as cppcore
@@ -443,6 +444,21 @@ def getFeatureValues(
         return list(map_result)
     else:
         return map_result
+
+
+def get_features_df(
+        traces,
+        featureNames,
+        parallel_map=None,
+        raise_warnings=True):
+    """Auxiliary function to return the feature results as a dataframe."""
+    feature_values = getFeatureValues(
+        traces,
+        featureNames,
+        parallel_map=parallel_map,
+        return_list=True,
+        raise_warnings=raise_warnings)
+    return pd.DataFrame(feature_values)
 
 
 def get_py_feature(featureName):

--- a/efel/tests/test_api.py
+++ b/efel/tests/test_api.py
@@ -1,0 +1,28 @@
+"""Unit tests for api.py."""
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+import efel
+
+testdata_dir = Path(__file__).resolve().parent / 'testdata'
+
+
+def test_get_features_df():
+    """Test returning the features as a dataframe."""
+    trace_file = testdata_dir / 'basic' / 'min_AHP_values_single_peak.txt'
+    trace_values = np.loadtxt(trace_file)
+
+    trace = {
+        "T": trace_values[:, 0],
+        "V": trace_values[:, 1],
+        "stim_start": [1950],
+        "stim_end": [2050],
+    }
+    efeature_names = ["min_AHP_values", "min_AHP_indices", "peak_indices"]
+    features_df = efel.get_features_df([trace], efeature_names)
+    assert isinstance(features_df, pd.DataFrame)
+    assert features_df["peak_indices"][0] == [237]
+    assert features_df["min_AHP_indices"][0] is None
+    assert features_df["min_AHP_values"][0] is None

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     name="efel",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    install_requires=['numpy>=1.6', 'six'],
+    install_requires=['numpy>=1.6', 'six', 'pandas'],
     extras_require={'neo': ['neo[neomatlabio]>=0.5.1']},
     packages=['efel', 'efel.pyfeatures', 'efel.units'],
     author="BlueBrain Project, EPFL",


### PR DESCRIPTION
Adds an auxiliary function to get the features as a dataframe to enable filtering, selecting, missing value imputation etc. on the feature values.

The feature values dataframe looks like this:

![Screenshot_20230707_130932](https://github.com/BlueBrain/eFEL/assets/7026020/05de02a8-fac8-4975-aa80-4fd4d7fcec83)
