### PR TITLE
Docs cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,21 +102,10 @@ When you use this eFEL software for your research, we ask you to cite the follow
     }
 ```
 
-News
-====
-
-* 2023/01/04: We dropped support for Python 3.6. The eFEL code isn't automatically tested on 3.6 anymore.
-
-* 2021/08/25: We dropped support for Python 2.7. The eFEL code isn't automatically tested on 2.7 anymore.
-
-* 2016/01/17: We dropped support for Python 2.6. We're following the numpy and coverage module who also dropped support recently.
-For the moment eFEL still works with Python 2.6, you will just have to install the right (older) versions of the dependencies.
-The eFEL code isn't automatically tested on 2.6 anymore.
-
 Requirements
 ============
 
-* [Python 3.7+](https://www.python.org/download/releases/3.4.3/)
+* [Python 3.8+](https://www.python.org/downloads/)
 * [Pip](https://pip.pypa.io) (installed by default in newer versions of Python)
 * C++ compiler that can be used by pip
 * [Numpy](http://www.numpy.org) (will be installed automatically by pip)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Requirements
 ------------
-* `Python 3.4+ <https://www.python.org/download/releases/3.4.3/>`_
+* `Python <https://www.python.org/downloads/>`_
 * `Pip <https://pip.pypa.io>`_ (installed by default in newer versions of Python)
 * `Numpy <http://www.numpy.org>`_ (will be installed automatically by pip)
 * The instruction below are written assuming you have access to a command shell on Linux / UNIX / MacOSX / Cygwin
@@ -13,12 +13,12 @@ Installation using pip
 
 The easiest way to install eFEL is to use `pip <https://pip.pypa.io>`_::
 
-    pip install git+git://github.com/BlueBrain/eFEL
+    pip install efel
 
 In case you don't have administrator access this command might fail with a
 permission error. In that case you could install eFEL in your home directory::
 
-    pip install --user git+git://github.com/BlueBrain/eFEL
+    pip install efel --user
 
 Or you could use a `python virtual environment <https://virtualenv.pypa.io>`_::
 

--- a/docs/source/python_example1.rst
+++ b/docs/source/python_example1.rst
@@ -65,8 +65,8 @@ The code and example trace are available
         for trace_results in traces_results:
             # trace_result is a dictionary, with as keys the requested eFeatures
             for feature_name, feature_values in trace_results.items():
-                print "Feature %s has the following values: %s" % \
-                    (feature_name, ', '.join([str(x) for x in feature_values]))
+                print("Feature %s has the following values: %s" % \
+                    (feature_name, ', '.join([str(x) for x in feature_values])))
 
 
     if __name__ == '__main__':

--- a/efel/api.py
+++ b/efel/api.py
@@ -24,9 +24,6 @@ Copyright (c) 2015, EPFL/Blue Brain Project
  along with this library; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 """
-
-from __future__ import division
-
 # pylint: disable=W0602,W0603,W0702, F0401, W0612, R0912
 
 import os

--- a/examples/basic/basic_example1.py
+++ b/examples/basic/basic_example1.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 """Basic example 1 for eFEL"""
 
 import os

--- a/tests/update_expectedresults.py
+++ b/tests/update_expectedresults.py
@@ -2,8 +2,6 @@
 
 """Test all features on an example trace"""
 
-from __future__ import print_function
-
 """
 Copyright (c) 2015, Blue Brain Project/EPFL
 

--- a/tests/update_featurenames.py
+++ b/tests/update_featurenames.py
@@ -2,8 +2,6 @@
 
 """Update the featurenames json file that contains the expected names"""
 
-from __future__ import print_function
-
 """
 Copyright (c) 2015, Blue Brain Project/EPFL
 


### PR DESCRIPTION
#### CHANGES

* fix links in docs, some download links were outdated e.g. (https://www.python.org/download/releases/)
* remove py2 style print functions or from `__future__ import print_function`
* remove old news from README that says we dropped py26 in 2016 etc. Even py37 is no longer supported today (https://endoflife.date/python). We can perhaps consider having a CHANGELOG file in the future to list the important changes as well as the versions introducing them.