### PR TITLE
cppcore: implement memoization once for all features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   tag:
     name: Bump version, push tag and make a release
     needs: call-test-workflow
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
@@ -54,13 +54,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         python: [cp38, cp39, cp310, cp311]
         arch: [x86_64, amd64]
         exclude:
           - os: macos-latest
             arch: amd64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             arch: amd64
           - os: windows-latest
             arch: x86_64
@@ -90,7 +90,7 @@ jobs:
   
   tarball:
     name: Build tarball
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [call-test-workflow, tag]
     steps:
       - uses: actions/checkout@v3
@@ -111,7 +111,7 @@ jobs:
 
   publish:
     name: Release and Publish on PyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [call-test-workflow, tag, wheels, tarball]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -11,7 +11,7 @@ jobs:
   
   keep-workflow-alive:
     name: Keep workflow alive
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,13 +27,6 @@ jobs:
 
     - name: Run tox
       run: |
-        sudo apt update
-        sudo apt install -y g++-11 gcc-11
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 60 --slave /usr/bin/g++ g++ /usr/bin/g++-11
-        sudo update-alternatives --config gcc
-        g++ --version
-        gcc --version
-        cmake --version
         tox  # this does not call docs
 
   coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
@@ -30,7 +30,7 @@ jobs:
         tox  # this does not call docs
 
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -56,7 +56,7 @@ jobs:
       with:
         fail_ci_if_error: false
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,13 @@ jobs:
 
     - name: Run tox
       run: |
+        sudo apt update
+        sudo apt install -y g++-11 gcc-11
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 60 --slave /usr/bin/g++ g++ /usr/bin/g++-11
+        sudo update-alternatives --config gcc
+        g++ --version
         gcc --version
+        cmake --version
         tox  # this does not call docs
 
   coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,9 @@ jobs:
         pip install tox tox-gh-actions
 
     - name: Run tox
-      run: tox  # this does not call docs
+      run: |
+        gcc --version
+        tox  # this does not call docs
 
   coverage:
     runs-on: ubuntu-20.04

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.9"
 

--- a/efel/cppcore/CMakeLists.txt
+++ b/efel/cppcore/CMakeLists.txt
@@ -15,15 +15,22 @@
 # along with this library; if not, write to the Free Software Foundation, Inc., 
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.                   
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.12)
 
-set(CMAKE_BUILD_TYPE Debug)
+# Set Compiler
+set(CMAKE_C_COMPILER g++)
+set(CMAKE_CXX_COMPILER g++)
+
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 
 set(FEATURESRCS Utils.cpp LibV1.cpp LibV2.cpp LibV3.cpp LibV5.cpp
     FillFptrTable.cpp DependencyTree.cpp efel.cpp cfeature.cpp
     mapoperations.cpp)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_library(efelStatic ${FEATURESRCS})
 set_target_properties(efelStatic PROPERTIES OUTPUT_NAME efel)

--- a/efel/cppcore/CMakeLists.txt
+++ b/efel/cppcore/CMakeLists.txt
@@ -17,20 +17,18 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-# Set Compiler
-set(CMAKE_C_COMPILER g++)
-set(CMAKE_CXX_COMPILER g++)
-
-
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(CMAKE_BUILD_TYPE Debug)
 
 set(FEATURESRCS Utils.cpp LibV1.cpp LibV2.cpp LibV3.cpp LibV5.cpp
     FillFptrTable.cpp DependencyTree.cpp efel.cpp cfeature.cpp
     mapoperations.cpp)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 add_library(efelStatic ${FEATURESRCS})
 set_target_properties(efelStatic PROPERTIES OUTPUT_NAME efel)

--- a/efel/cppcore/CMakeLists.txt
+++ b/efel/cppcore/CMakeLists.txt
@@ -29,6 +29,8 @@ set(FEATURESRCS Utils.cpp LibV1.cpp LibV2.cpp LibV3.cpp LibV5.cpp
     mapoperations.cpp)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+
 
 add_library(efelStatic ${FEATURESRCS})
 set_target_properties(efelStatic PROPERTIES OUTPUT_NAME efel)

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -48,10 +48,7 @@ std::string to_string(const T& value) {
 int LibV1::interpolate(mapStr2intVec& IntFeatureData,
                        mapStr2doubleVec& DoubleFeatureData,
                        mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(IntFeatureData, StringData, "interpolate", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   vector<double> V, T, VIntrpol, TIntrpol, InterpStepVec;
   vector<int> intrpolte;
@@ -90,13 +87,8 @@ int LibV1::Spikecount(mapStr2intVec& IntFeatureData,
                       mapStr2doubleVec& DoubleFeatureData,
                       mapStr2Str& StringData) {
   int retval;
-  int nsize;
   size_t spikecount_value;
-  retval =
-      CheckInMap(IntFeatureData, StringData, "Spikecount", nsize);
-  if (retval) {
-    return nsize;
-  }
+
   vector<int> peakindices;
   retval = getVec(IntFeatureData, StringData, "peak_indices",
                      peakindices);
@@ -118,11 +110,7 @@ int LibV1::Spikecount(mapStr2intVec& IntFeatureData,
 int LibV1::ISI_values(mapStr2intVec& IntFeatureData,
                       mapStr2doubleVec& DoubleFeatureData,
                       mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "ISI_values",
-                            nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   vector<double> VecISI, pvTime;
   retVal = getVec(DoubleFeatureData, StringData, "peak_time", pvTime);
@@ -170,10 +158,6 @@ static int __ISI_CV(const vector<double>& isivalues, vector<double>& isicv) {
 int LibV1::ISI_CV(mapStr2intVec& IntFeatureData,
                   mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "ISI_CV", nsize);
-  if (retval) return nsize;
 
   vector<double> isivalues;
   retval = getVec(DoubleFeatureData, StringData, "ISI_values",
@@ -192,11 +176,7 @@ int LibV1::ISI_CV(mapStr2intVec& IntFeatureData,
 int LibV1::peak_voltage(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "peak_voltage", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   // vector<int> PeakI = getVec(IntFeatureData, StringData,
   // string("peak_indices"));
@@ -220,11 +200,7 @@ int LibV1::firing_rate(mapStr2intVec& IntFeatureData,
                        mapStr2doubleVec& DoubleFeatureData,
                        mapStr2Str& StringData) {
   // printf("\n  LibV1  This is inside firing_rate()");
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "mean_frequency", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   vector<double> stimStart, stimEnd, peakVTime, firing_rate;
   double lastAPTime = 0.;
@@ -254,10 +230,7 @@ int LibV1::firing_rate(mapStr2intVec& IntFeatureData,
 int LibV1::peak_time(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "peak_time", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   vector<int> PeakI;
   vector<double> T, pvTime;
@@ -276,11 +249,7 @@ int LibV1::peak_time(mapStr2intVec& IntFeatureData,
 int LibV1::first_spike_time(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "time_to_first_spike", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   vector<double> first_spike;
   vector<double> peaktime;
@@ -301,10 +270,7 @@ int LibV1::first_spike_time(mapStr2intVec& IntFeatureData,
 int LibV1::AP_height(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP_height", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   vector<double> vPeak;
   retVal = getVec(DoubleFeatureData, StringData, "peak_voltage", vPeak);
@@ -318,11 +284,7 @@ int LibV1::AP_height(mapStr2intVec& IntFeatureData,
 int LibV1::AP_amplitude(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "AP_amplitude", nSize);
-  if (retVal > 0)
-    return nSize;
+  int retVal;
 
   vector<double> peakvoltage;
   vector<double> peaktime;
@@ -426,12 +388,6 @@ int LibV1::AHP_depth_abs_slow(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AHP_depth_abs_slow", nsize);
-  if (retval) {
-    return nsize;
-  }
 
   vector<double> t;
   retval = getVec(DoubleFeatureData, StringData, "T", t);
@@ -474,10 +430,6 @@ int LibV1::AHP_depth_abs_slow(mapStr2intVec& IntFeatureData,
 int LibV1::AHP_slow_time(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "AHP_slow_time", nSize);
-  if (retVal) return nSize;
   return -1;
 }
 
@@ -512,11 +464,7 @@ static int __burst_ISI_indices(double BurstFactor, vector<int>& PeakIndex,
 int LibV1::burst_ISI_indices(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "burst_ISI_indices", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   vector<int> PeakIndex, BurstIndex;
   vector<double> ISIValues, tVec;
@@ -575,11 +523,7 @@ static int __burst_mean_freq(vector<double>& PVTime, vector<int>& BurstIndex,
 int LibV1::burst_mean_freq(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "burst_mean_freq", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   int IgnoreFirstISI;
   vector<int> BurstIndex, retIgnore;
@@ -609,11 +553,7 @@ int LibV1::burst_mean_freq(mapStr2intVec& IntFeatureData,
 int LibV1::burst_number(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(IntFeatureData, StringData, "burst_number", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   vector<double> BurstMeanFreq;
   vector<int> BurstNum;
@@ -662,11 +602,7 @@ static int __interburst_voltage(vector<int>& BurstIndex, vector<int>& PeakIndex,
 int LibV1::interburst_voltage(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "interburst_voltage", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   int IgnoreFirstISI;
   vector<int> BurstIndex, PeakIndex, retIgnore;
@@ -753,11 +689,7 @@ static int __adaptation_index(double spikeSkipf, int maxnSpike,
 int LibV1::adaptation_index(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "adaptation_index", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   vector<double> peakVTime, stimStart, stimEnd, OffSetVec, spikeSkipf,
       adaptation_index;
@@ -844,10 +776,6 @@ int LibV1::adaptation_index2(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "adaptation_index2", nsize);
-  if (retval) return nsize;
 
   vector<double> peakvoltagetime;
   retval = getVec(DoubleFeatureData, StringData, "peak_time",
@@ -888,10 +816,6 @@ int LibV1::trace_check(mapStr2intVec& IntFeatureData,
                        mapStr2doubleVec& DoubleFeatureData,
                        mapStr2Str& StringData) {
   int retval;
-  int size;
-  retval = CheckInMap(IntFeatureData, StringData, "trace_check", size);
-  if (retval)
-    return size;
 
   vector<double> peak_time;
   vector<double> stim_start;
@@ -1009,11 +933,7 @@ static int __spike_width2(vector<double>& t, vector<double>& V,
 int LibV1::spike_width2(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "spike_width2", nSize);
-  if (retVal)
-    return nSize;
+  int retVal;
 
   vector<int> PeakIndex, minAHPIndex;
   vector<double> V, t, dv1, dv2, spike_width2;
@@ -1187,11 +1107,6 @@ int LibV1::time_constant(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "time_constant", nSize);
-  if (retVal)
-    return nSize;
 
   vector<double> v;
   vector<double> t;
@@ -1253,11 +1168,6 @@ int LibV1::voltage_deflection(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "voltage_deflection", nSize);
-  if (retVal)
-    return nSize;
 
   vector<double> v;
   vector<double> t;
@@ -1292,11 +1202,6 @@ int LibV1::ohmic_input_resistance(mapStr2intVec& IntFeatureData,
                                   mapStr2doubleVec& DoubleFeatureData,
                                   mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "ohmic_input_resistance", nSize);
-  if (retVal)
-    return nSize;
 
   vector<double> voltage_deflection;
   retVal = getVec(DoubleFeatureData, StringData,
@@ -1355,11 +1260,6 @@ int LibV1::maximum_voltage(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "maximum_voltage", nSize);
-  if (retVal)
-    return nSize;
 
   vector<double> v;
   vector<double> t;
@@ -1388,11 +1288,6 @@ int LibV1::minimum_voltage(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "minimum_voltage", nSize);
-  if (retVal)
-    return nSize;
 
   vector<double> v;
   vector<double> t;
@@ -1433,11 +1328,6 @@ int LibV1::steady_state_voltage(mapStr2intVec& IntFeatureData,
                                 mapStr2doubleVec& DoubleFeatureData,
                                 mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "steady_state_voltage", nSize);
-  if (retVal)
-    return nSize;
 
   vector<double> v;
   retVal = getVec(DoubleFeatureData, StringData, "V", v);
@@ -1479,12 +1369,6 @@ int LibV1::single_burst_ratio(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "single_burst_ratio", nsize);
-  if (retval) {
-    return nsize;
-  }
 
   vector<double> isivalues;
   retval = getVec(DoubleFeatureData, StringData, "ISI_values", isivalues);
@@ -1603,13 +1487,6 @@ int LibV1::AP_width(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "AP_width",
-                            nsize);
-  if (retval) {
-    return nsize;
-  }
-
   vector<double> t;
   retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
@@ -1660,13 +1537,6 @@ int LibV1::doublet_ISI(mapStr2intVec& IntFeatureData,
                        mapStr2doubleVec& DoubleFeatureData,
                        mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "doublet_ISI", nsize);
-  if (retval) {
-    return nsize;
-  }
-
   vector<double> pvt;
   retval = getVec(DoubleFeatureData, StringData, "peak_time", pvt);
   if (retval < 2) {
@@ -1694,12 +1564,6 @@ int LibV1::AHP_depth_slow(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "AHP_depth_slow", nsize);
-  if (retval) {
-    return nsize;
-  }
-
   vector<double> voltagebase;
   retval = getVec(DoubleFeatureData, StringData, "voltage_base",
                         voltagebase);
@@ -1733,12 +1597,6 @@ int LibV1::AHP_depth(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "AHP_depth", nsize);
-  if (retval) {
-    return nsize;
-  }
-
   vector<double> voltagebase;
   retval = getVec(DoubleFeatureData, StringData, "voltage_base",
                         voltagebase);
@@ -1772,13 +1630,6 @@ int LibV1::AP_amplitude_diff(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_amplitude_diff", nsize);
-  if (retval) {
-    return nsize;
-  }
-
   vector<double> apamplitude;
   retval = getVec(DoubleFeatureData, StringData, "AP_amplitude",
                         apamplitude);
@@ -1808,13 +1659,6 @@ int LibV1::AHP_depth_diff(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AHP_depth_diff", nsize);
-  if (retval) {
-    return nsize;
-  }
-
   vector<double> ahpdepth;
   retval = getVec(DoubleFeatureData, StringData, "AHP_depth",
                         ahpdepth);

--- a/efel/cppcore/LibV2.cpp
+++ b/efel/cppcore/LibV2.cpp
@@ -731,7 +731,6 @@ int LibV2::BPAPatt3(mapStr2intVec& IntFeatureData,
 // unit: Hz / nA
 int LibV2::E39(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
-  int retval;
   vector<string> stim_params;
   // retrieve the complete suffixes of all traces where the suffix matches
   // "IDthreshold":

--- a/efel/cppcore/LibV2.cpp
+++ b/efel/cppcore/LibV2.cpp
@@ -60,13 +60,6 @@ int LibV2::AP_rise_indices(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(IntFeatureData, StringData, "AP_rise_indices",
-                         nSize);
-  if (retVal) {
-    return nSize;
-  }
-
   vector<double> v;
   retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
@@ -106,12 +99,6 @@ int LibV2::AP_fall_indices(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(IntFeatureData, StringData, "AP_fall_indices", nSize);
-  if (retVal) {
-    return nSize;
-  }
-
   vector<double> v;
   retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
@@ -150,12 +137,6 @@ int LibV2::AP_duration(mapStr2intVec& IntFeatureData,
                        mapStr2doubleVec& DoubleFeatureData,
                        mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_duration", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> t;
   retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
@@ -191,12 +172,6 @@ int LibV2::AP_duration_half_width(mapStr2intVec& IntFeatureData,
                                   mapStr2doubleVec& DoubleFeatureData,
                                   mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_duration_half_width", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> t;
   retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
@@ -263,12 +238,6 @@ int LibV2::AP_rise_time(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_rise_time", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> t;
   retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
@@ -332,12 +301,6 @@ int LibV2::AP_fall_time(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_fall_time", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> t;
   retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
@@ -374,12 +337,6 @@ int LibV2::AP_rise_rate(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_rise_rate", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> t;
   retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
@@ -419,12 +376,6 @@ int LibV2::AP_fall_rate(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_fall_rate", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> t;
   retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
@@ -465,11 +416,6 @@ int LibV2::fast_AHP(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "fast_AHP", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> v;
   retval = getVec(DoubleFeatureData, StringData, "V", v);
   if (retval < 0) return -1;
@@ -507,12 +453,6 @@ int LibV2::AP_amplitude_change(mapStr2intVec& IntFeatureData,
                                mapStr2doubleVec& DoubleFeatureData,
                                mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_amplitude_change", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> apamplitude;
   retval = getVec(DoubleFeatureData, StringData, "AP_amplitude",
                         apamplitude);
@@ -543,12 +483,6 @@ int LibV2::AP_duration_change(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_duration_change", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> apduration;
   retval = getVec(DoubleFeatureData, StringData, "AP_duration",
                         apduration);
@@ -582,12 +516,6 @@ int LibV2::AP_duration_half_width_change(mapStr2intVec& IntFeatureData,
                                          mapStr2doubleVec& DoubleFeatureData,
                                          mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_duration_half_width_change", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> apdurationhalfwidth;
   retval = getVec(DoubleFeatureData, StringData,
                         "AP_duration_half_width", apdurationhalfwidth);
@@ -620,12 +548,6 @@ int LibV2::AP_rise_rate_change(mapStr2intVec& IntFeatureData,
                                mapStr2doubleVec& DoubleFeatureData,
                                mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_rise_rate_change", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> apriserate;
   retval = getVec(DoubleFeatureData, StringData, "AP_rise_rate",
                         apriserate);
@@ -656,12 +578,6 @@ int LibV2::AP_fall_rate_change(mapStr2intVec& IntFeatureData,
                                mapStr2doubleVec& DoubleFeatureData,
                                mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_fall_rate_change", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> apfallrate;
   retval = getVec(DoubleFeatureData, StringData, "AP_fall_rate",
                         apfallrate);
@@ -692,12 +608,6 @@ int LibV2::fast_AHP_change(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "fast_AHP_change", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> fastahp;
   retval = getVec(DoubleFeatureData, StringData, "fast_AHP", fastahp);
   if (retval < 0) return -1;
@@ -715,11 +625,6 @@ int LibV2::fast_AHP_change(mapStr2intVec& IntFeatureData,
 int LibV2::E6(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "E6", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e6;
   retval = mean_traces_double(DoubleFeatureData, "AP_amplitude", "APWaveForm",
                               0, e6);
@@ -735,11 +640,6 @@ int LibV2::E6(mapStr2intVec& IntFeatureData,
 int LibV2::E7(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "E7", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e7;
   retval =
       mean_traces_double(DoubleFeatureData, "AP_duration", "APWaveForm", 0, e7);
@@ -756,12 +656,6 @@ int LibV2::BPAPatt2(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "BPAPatt2",
-                            nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> peakvoltage;
   retval = getDoubleParam(DoubleFeatureData, "peak_voltage;location_soma",
                           peakvoltage);
@@ -800,12 +694,6 @@ int LibV2::BPAPatt3(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "BPAPatt3",
-                            nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> peakvoltage;
   retval = getDoubleParam(DoubleFeatureData, "peak_voltage;location_soma",
                           peakvoltage);
@@ -844,12 +732,6 @@ int LibV2::BPAPatt3(mapStr2intVec& IntFeatureData,
 int LibV2::E39(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E39", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<string> stim_params;
   // retrieve the complete suffixes of all traces where the suffix matches
   // "IDthreshold":
@@ -889,11 +771,7 @@ int LibV2::E39(mapStr2intVec& IntFeatureData,
 int LibV2::E39_cod(mapStr2intVec& IntFeatureData,
                    mapStr2doubleVec& DoubleFeatureData,
                    mapStr2Str& StringData) {
-  int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E39_cod", nsize);
-  return retval;
+  return 1;
 }
 // end of E39_cod
 
@@ -907,12 +785,6 @@ int LibV2::amp_drop_first_second(mapStr2intVec& IntFeatureData,
                                  mapStr2doubleVec& DoubleFeatureData,
                                  mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "amp_drop_first_second", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> peakvoltage;
   retval = getVec(DoubleFeatureData, StringData, "peak_voltage",
                         peakvoltage);
@@ -935,11 +807,6 @@ int LibV2::amp_drop_first_second(mapStr2intVec& IntFeatureData,
 int LibV2::E2(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "E2", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e2;
   retval = mean_traces_double(DoubleFeatureData, "amp_drop_first_second",
                               "APDrop", 0, e2);
@@ -961,12 +828,6 @@ int LibV2::amp_drop_first_last(mapStr2intVec& IntFeatureData,
                                mapStr2doubleVec& DoubleFeatureData,
                                mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "amp_drop_first_last", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> peakvoltage;
   retval = getVec(DoubleFeatureData, StringData, "peak_voltage",
                         peakvoltage);
@@ -989,11 +850,6 @@ int LibV2::amp_drop_first_last(mapStr2intVec& IntFeatureData,
 int LibV2::E3(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "E3", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e3;
   retval = mean_traces_double(DoubleFeatureData, "amp_drop_first_last",
                               "APDrop", 0, e3);
@@ -1015,12 +871,6 @@ int LibV2::amp_drop_second_last(mapStr2intVec& IntFeatureData,
                                 mapStr2doubleVec& DoubleFeatureData,
                                 mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "amp_drop_second_last", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> peakvoltage;
   retval = getVec(DoubleFeatureData, StringData, "peak_voltage",
                         peakvoltage);
@@ -1043,11 +893,6 @@ int LibV2::amp_drop_second_last(mapStr2intVec& IntFeatureData,
 int LibV2::E4(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "E4", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e4;
   retval = mean_traces_double(DoubleFeatureData, "amp_drop_second_last",
                               "APDrop", 0, e4);
@@ -1079,12 +924,6 @@ int LibV2::max_amp_difference(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "max_amp_difference", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> peakvoltage;
   retval = getVec(DoubleFeatureData, StringData, "peak_voltage",
                         peakvoltage);
@@ -1107,11 +946,6 @@ int LibV2::max_amp_difference(mapStr2intVec& IntFeatureData,
 int LibV2::E5(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "E5", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e5;
   retval = mean_traces_double(DoubleFeatureData, "max_amp_difference", "APDrop",
                               0, e5);
@@ -1127,11 +961,6 @@ int LibV2::E5(mapStr2intVec& IntFeatureData,
 int LibV2::E8(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "E8", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e8;
   retval = mean_traces_double(DoubleFeatureData, "AP_duration_half_width",
                               "APWaveForm", 0, e8);
@@ -1147,11 +976,6 @@ int LibV2::E8(mapStr2intVec& IntFeatureData,
 int LibV2::E9(mapStr2intVec& IntFeatureData,
               mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "E9", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e9;
   retval = mean_traces_double(DoubleFeatureData, "AP_rise_time", "APWaveForm",
                               0, e9);
@@ -1167,12 +991,6 @@ int LibV2::E9(mapStr2intVec& IntFeatureData,
 int LibV2::E10(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E10", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e10;
   retval = mean_traces_double(DoubleFeatureData, "AP_fall_time", "APWaveForm",
                               0, e10);
@@ -1188,12 +1006,6 @@ int LibV2::E10(mapStr2intVec& IntFeatureData,
 int LibV2::E11(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E11", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e11;
   retval = mean_traces_double(DoubleFeatureData, "AP_rise_rate", "APWaveForm",
                               0, e11);
@@ -1209,12 +1021,6 @@ int LibV2::E11(mapStr2intVec& IntFeatureData,
 int LibV2::E12(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E12", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e12;
   retval = mean_traces_double(DoubleFeatureData, "AP_fall_rate", "APWaveForm",
                               0, e12);
@@ -1230,12 +1036,6 @@ int LibV2::E12(mapStr2intVec& IntFeatureData,
 int LibV2::E13(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E13", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e13;
   retval =
       mean_traces_double(DoubleFeatureData, "fast_AHP", "APWaveForm", 0, e13);
@@ -1251,12 +1051,6 @@ int LibV2::E13(mapStr2intVec& IntFeatureData,
 int LibV2::E14(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E14", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e14;
   retval = mean_traces_double(DoubleFeatureData, "peak_voltage", "APWaveForm",
                               0, e14);
@@ -1273,12 +1067,6 @@ int LibV2::E14(mapStr2intVec& IntFeatureData,
 int LibV2::E15(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E15", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e15;
   retval = mean_traces_double(DoubleFeatureData, "AP_duration", "APWaveForm", 0,
                               e15);
@@ -1295,12 +1083,6 @@ int LibV2::E15(mapStr2intVec& IntFeatureData,
 int LibV2::E16(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E16", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e16;
   retval = mean_traces_double(DoubleFeatureData, "AP_duration_half_width",
                               "APWaveForm", 0, e16);
@@ -1317,12 +1099,6 @@ int LibV2::E16(mapStr2intVec& IntFeatureData,
 int LibV2::E17(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E17", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e17;
   retval = mean_traces_double(DoubleFeatureData, "AP_rise_time", "APWaveForm",
                               0, e17);
@@ -1339,12 +1115,6 @@ int LibV2::E17(mapStr2intVec& IntFeatureData,
 int LibV2::E18(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E18", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e18;
   retval = mean_traces_double(DoubleFeatureData, "AP_fall_time", "APWaveForm",
                               0, e18);
@@ -1361,12 +1131,6 @@ int LibV2::E18(mapStr2intVec& IntFeatureData,
 int LibV2::E19(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E19", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e19;
   retval = mean_traces_double(DoubleFeatureData, "AP_rise_rate", "APWaveForm",
                               0, e19);
@@ -1383,12 +1147,6 @@ int LibV2::E19(mapStr2intVec& IntFeatureData,
 int LibV2::E20(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E20", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e20;
   retval = mean_traces_double(DoubleFeatureData, "AP_fall_rate", "APWaveForm",
                               0, e20);
@@ -1405,12 +1163,6 @@ int LibV2::E20(mapStr2intVec& IntFeatureData,
 int LibV2::E21(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E21", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e21;
   retval =
       mean_traces_double(DoubleFeatureData, "fast_AHP", "APWaveForm", 0, e21);
@@ -1427,12 +1179,6 @@ int LibV2::E21(mapStr2intVec& IntFeatureData,
 int LibV2::E22(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E22", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e22;
   retval = mean_traces_double(DoubleFeatureData, "AP_amplitude_change",
                               "APWaveForm", 0, e22);
@@ -1447,12 +1193,6 @@ int LibV2::E22(mapStr2intVec& IntFeatureData,
 int LibV2::E23(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E23", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e23;
   retval = mean_traces_double(DoubleFeatureData, "AP_duration_change",
                               "APWaveForm", 0, e23);
@@ -1467,12 +1207,6 @@ int LibV2::E23(mapStr2intVec& IntFeatureData,
 int LibV2::E24(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E24", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e24;
   retval = mean_traces_double(
       DoubleFeatureData, "AP_duration_half_width_change", "APWaveForm", 0, e24);
@@ -1487,12 +1221,6 @@ int LibV2::E24(mapStr2intVec& IntFeatureData,
 int LibV2::E25(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E25", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e25;
   retval = mean_traces_double(DoubleFeatureData, "AP_rise_rate_change",
                               "APWaveForm", 0, e25);
@@ -1507,12 +1235,6 @@ int LibV2::E25(mapStr2intVec& IntFeatureData,
 int LibV2::E26(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E26", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e26;
   retval = mean_traces_double(DoubleFeatureData, "AP_fall_rate_change",
                               "APWaveForm", 0, e26);
@@ -1527,12 +1249,6 @@ int LibV2::E26(mapStr2intVec& IntFeatureData,
 int LibV2::E27(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E27", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e27;
   retval = mean_traces_double(DoubleFeatureData, "fast_AHP_change",
                               "APWaveForm", 0, e27);
@@ -1576,12 +1292,6 @@ int LibV2::steady_state_hyper(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "steady_state_hyper",
-                            nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> v;
   retval = getVec(DoubleFeatureData, StringData, "V", v);
   if (retval < 0) return -1;
@@ -1604,12 +1314,6 @@ int LibV2::steady_state_hyper(mapStr2intVec& IntFeatureData,
 int LibV2::E40(mapStr2intVec& IntFeatureData,
                mapStr2doubleVec& DoubleFeatureData, mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "E40", nsize);
-  if (retval) {
-    return nsize;
-  }
   vector<double> e40;
   retval = mean_traces_double(DoubleFeatureData, "time_to_first_spike",
                               "IDrest", 0, e40);

--- a/efel/cppcore/LibV3.cpp
+++ b/efel/cppcore/LibV3.cpp
@@ -69,12 +69,6 @@ int LibV3::depolarized_base(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(IntFeatureData, StringData, "depolarized_base",
-                         nSize);
-  if (retVal) {
-    return nSize;
-  }
   vector<double> t;
   retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;

--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -76,10 +76,6 @@ static int __ISI_log_slope(const vector<double>& isiValues,
 int LibV5::ISI_log_slope(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
-  int size;
-  if (CheckInMap(DoubleFeatureData, StringData, "ISI_log_slope", size)) {
-    return size;
-  }
   vector<double> isivalues;
   vector<double> slope;
   if (getVec(DoubleFeatureData, StringData, "ISI_values", isivalues) <=
@@ -99,11 +95,6 @@ int LibV5::ISI_log_slope(mapStr2intVec& IntFeatureData,
 int LibV5::ISI_semilog_slope(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
-  int size;
-  if (CheckInMap(DoubleFeatureData, StringData, "ISI_semilog_slope",
-                       size)) {
-    return size;
-  }
   vector<double> isivalues;
   vector<double> slope;
   if (getVec(DoubleFeatureData, StringData, "ISI_values", isivalues) <=
@@ -127,10 +118,6 @@ int LibV5::ISI_log_slope_skip(mapStr2intVec& IntFeatureData,
   vector<int> maxnSpike;
   vector<double> spikeSkipf;
 
-  if (CheckInMap(DoubleFeatureData, StringData, "ISI_log_slope_skip",
-                       size)) {
-    return size;
-  }
   vector<double> isivalues;
   vector<double> slope;
   if (getVec(DoubleFeatureData, StringData, "ISI_values", isivalues) <=
@@ -166,11 +153,7 @@ int LibV5::ISI_log_slope_skip(mapStr2intVec& IntFeatureData,
 int LibV5::time_to_second_spike(mapStr2intVec& IntFeatureData,
                                 mapStr2doubleVec& DoubleFeatureData,
                                 mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "time_to_second_spike", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> second_spike;
   vector<double> peaktime;
   vector<double> stimstart;
@@ -192,11 +175,7 @@ int LibV5::time_to_second_spike(mapStr2intVec& IntFeatureData,
 int LibV5::time_to_last_spike(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
-  int retVal, nSize;
-
-  retVal = CheckInMap(DoubleFeatureData, StringData, "time_to_last_spike",
-                            nSize);
-  if (retVal) return nSize;
+  int retVal;
 
   vector<double> last_spike;
   vector<double> peaktime;
@@ -224,11 +203,7 @@ int LibV5::time_to_last_spike(mapStr2intVec& IntFeatureData,
 int LibV5::inv_first_ISI(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "inv_first_ISI", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> all_isi_values_vec;
   double inv_first_ISI;
   vector<double> inv_first_ISI_vec;
@@ -249,11 +224,7 @@ int LibV5::inv_first_ISI(mapStr2intVec& IntFeatureData,
 int LibV5::inv_second_ISI(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "inv_second_ISI", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> all_isi_values_vec;
   double inv_second_ISI;
   vector<double> inv_second_ISI_vec;
@@ -274,11 +245,7 @@ int LibV5::inv_second_ISI(mapStr2intVec& IntFeatureData,
 int LibV5::inv_third_ISI(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "inv_third_ISI", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> all_isi_values_vec;
   double inv_third_ISI;
   vector<double> inv_third_ISI_vec;
@@ -299,11 +266,7 @@ int LibV5::inv_third_ISI(mapStr2intVec& IntFeatureData,
 int LibV5::inv_fourth_ISI(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "inv_fourth_ISI", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> all_isi_values_vec;
   double inv_fourth_ISI;
   vector<double> inv_fourth_ISI_vec;
@@ -324,11 +287,7 @@ int LibV5::inv_fourth_ISI(mapStr2intVec& IntFeatureData,
 int LibV5::inv_fifth_ISI(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "inv_fifth_ISI", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> all_isi_values_vec;
   double inv_fifth_ISI;
   vector<double> inv_fifth_ISI_vec;
@@ -349,10 +308,7 @@ int LibV5::inv_fifth_ISI(mapStr2intVec& IntFeatureData,
 int LibV5::inv_last_ISI(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "inv_last_ISI", nSize);
-  if (retVal) return nSize;
+  int retVal;
   vector<double> all_isi_values_vec;
   double inv_last_ISI;
   vector<double> inv_last_ISI_vec;
@@ -372,10 +328,7 @@ int LibV5::inv_last_ISI(mapStr2intVec& IntFeatureData,
 int LibV5::inv_time_to_first_spike(mapStr2intVec& IntFeatureData,
                                    mapStr2doubleVec& DoubleFeatureData,
                                    mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "inv_time_to_first_spike", nSize);
-  if (retVal) return nSize;
+  int retVal;
 
   vector<double> time_to_first_spike_vec;
   double inv_time_to_first_spike;
@@ -438,11 +391,7 @@ static int __min_AHP_indices(const vector<double>& t, const vector<double>& v,
 int LibV5::min_AHP_indices(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
-  int retVal, nSize;
-
-  retVal = CheckInMap(IntFeatureData, StringData, "min_AHP_indices", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   double stim_start, stim_end;
   vector<int> min_ahp_indices, strict_stiminterval_vec, peak_indices;
   vector<double> v, t, stim_start_vec, stim_end_vec, min_ahp_values;
@@ -509,10 +458,6 @@ int LibV5::min_AHP_indices(mapStr2intVec& IntFeatureData,
 int LibV5::min_AHP_values(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "min_AHP_values", nSize);
-  if (retVal) return nSize;
   return -1;
 }
 
@@ -521,10 +466,7 @@ int LibV5::min_AHP_values(mapStr2intVec& IntFeatureData,
 int LibV5::AHP_depth_abs(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "AHP_depth_abs", nSize);
-  if (retVal) return nSize;
+  int retVal;
 
   vector<double> vAHP;
   retVal = getVec(DoubleFeatureData, StringData, "min_AHP_values", vAHP);
@@ -580,10 +522,7 @@ static int __spike_width1(const vector<double>& t, const vector<double>& v,
 int LibV5::spike_width1(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "spike_half_width",
-                            nSize);
-  if (retVal) return nSize;
+  int retVal;
 
   vector<int> PeakIndex, minAHPIndex;
   vector<double> V, t, dv1, dv2, spike_width1;
@@ -718,14 +657,6 @@ int LibV5::AP_begin_indices(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-
-  // Check if calculated already
-  retVal = CheckInMap(IntFeatureData, StringData, "AP_begin_indices", nSize);
-  if (retVal) {
-    return nSize;
-  }
-
   // Get input parameters
   vector<double> t;
   retVal = getVec(DoubleFeatureData, StringData, "T", t);
@@ -812,12 +743,6 @@ int LibV5::AP_end_indices(mapStr2intVec& IntFeatureData,
                           mapStr2Str& StringData) {
 
   int retVal;
-  int nSize;
-  retVal = CheckInMap(IntFeatureData, StringData, "AP_end_indices", nSize);
-  if (retVal) {
-    return nSize;
-  }
-
   vector<double> t;
   retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) return -1;
@@ -864,11 +789,7 @@ static int __irregularity_index(vector<double>& isiValues,
 int LibV5::irregularity_index(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "irregularity_index",
-                            nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> isiValues, irregularity_index;
   retVal = getVec(DoubleFeatureData, StringData, "ISI_values", isiValues);
   if (retVal < 0) return -1;
@@ -903,11 +824,7 @@ static int __number_initial_spikes(vector<double>& peak_times, double stimstart,
 int LibV5::number_initial_spikes(mapStr2intVec& IntFeatureData,
                                  mapStr2doubleVec& DoubleFeatureData,
                                  mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "number_initial_spikes", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> peak_times, initial_perc;
   vector<int> number_initial_spikes;
   retVal = getVec(DoubleFeatureData, StringData, "peak_time", peak_times);
@@ -940,10 +857,7 @@ int LibV5::number_initial_spikes(mapStr2intVec& IntFeatureData,
 int LibV5::AP1_amp(mapStr2intVec& IntFeatureData,
                    mapStr2doubleVec& DoubleFeatureData,
                    mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP1_amp", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> AP_amplitudes, AP1_amp;
   retVal = getVec(DoubleFeatureData, StringData, "AP_amplitude",
                         AP_amplitudes);
@@ -962,9 +876,7 @@ int LibV5::AP1_amp(mapStr2intVec& IntFeatureData,
 int LibV5::APlast_amp(mapStr2intVec& IntFeatureData,
                       mapStr2doubleVec& DoubleFeatureData,
                       mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "APlast_amp", nSize);
-  if (retVal) return nSize;
+  int retVal;
   vector<double> AP_amplitudes, APlast_amp;
   int AP_amplitude_size;
 
@@ -985,10 +897,7 @@ int LibV5::APlast_amp(mapStr2intVec& IntFeatureData,
 int LibV5::AP1_peak(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP1_peak", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> peak_voltage, AP1_peak;
   retVal =
       getVec(DoubleFeatureData, StringData, "peak_voltage", peak_voltage);
@@ -1007,9 +916,7 @@ int LibV5::AP1_peak(mapStr2intVec& IntFeatureData,
 int LibV5::AP2_amp(mapStr2intVec& IntFeatureData,
                    mapStr2doubleVec& DoubleFeatureData,
                    mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP2_amp", nSize);
-  if (retVal) return nSize;
+  int retVal;
 
   vector<double> AP_amplitudes, AP2_amp;
   retVal = getVec(DoubleFeatureData, StringData, "AP_amplitude",
@@ -1030,9 +937,7 @@ int LibV5::AP2_amp(mapStr2intVec& IntFeatureData,
 int LibV5::AP2_peak(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP2_peak", nSize);
-  if (retVal) return nSize;
+  int retVal;
 
   vector<double> peak_voltage, AP2_peak;
   retVal =
@@ -1052,10 +957,7 @@ int LibV5::AP2_peak(mapStr2intVec& IntFeatureData,
 int LibV5::AP2_AP1_diff(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "AP2_AP1_diff", nSize);
-  if (retVal) return nSize;
+  int retVal;
 
   vector<double> AP_amplitudes, AP2_AP1_diff;
   retVal = getVec(DoubleFeatureData, StringData, "AP_amplitude",
@@ -1076,10 +978,7 @@ int LibV5::AP2_AP1_diff(mapStr2intVec& IntFeatureData,
 int LibV5::AP2_AP1_peak_diff(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP2_AP1_peak_diff",
-                            nSize);
-  if (retVal) return nSize;
+  int retVal;
   vector<double> peak_voltage, AP2_AP1_peak_diff;
   retVal =
       getVec(DoubleFeatureData, StringData, "peak_voltage", peak_voltage);
@@ -1101,9 +1000,7 @@ int LibV5::AP2_AP1_peak_diff(mapStr2intVec& IntFeatureData,
 int LibV5::AP1_width(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP1_width", nSize);
-  if (retVal) return nSize;
+  int retVal;
   vector<double> spike_half_width, AP1_width;
   retVal = getVec(DoubleFeatureData, StringData, "spike_half_width",
                         spike_half_width);
@@ -1123,10 +1020,7 @@ int LibV5::AP1_width(mapStr2intVec& IntFeatureData,
 int LibV5::AP2_width(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP2_width", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> spike_half_width, AP2_width;
   retVal = getVec(DoubleFeatureData, StringData, "spike_half_width",
                         spike_half_width);
@@ -1146,9 +1040,6 @@ int LibV5::AP2_width(mapStr2intVec& IntFeatureData,
 int LibV5::APlast_width(mapStr2intVec& IntFeatureData,
                       mapStr2doubleVec& DoubleFeatureData,
                       mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "APlast_width", nSize);
-  if (retVal) return nSize;
   vector<double> spike_half_width, APlast_width;
 
   int spike_half_width_size = 
@@ -1183,13 +1074,6 @@ int LibV5::AHP_time_from_peak(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "AHP_time_from_peak",
-                            nsize);
-  if (retval) {
-    return nsize;
-  }
-
   vector<double> T;
   retval = getVec(DoubleFeatureData, StringData, "T", T);
   if (retval < 0) return -1;
@@ -1227,14 +1111,6 @@ int LibV5::AHP_depth_from_peak(mapStr2intVec& IntFeatureData,
                                mapStr2doubleVec& DoubleFeatureData,
                                mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "AHP_depth_from_peak", nsize);
-
-  if (retval) {
-    return nsize;
-  }
-
   vector<double> V;
   retval = getVec(DoubleFeatureData, StringData, "V", V);
   if (retval < 0) return -1;
@@ -1262,11 +1138,7 @@ int LibV5::AHP_depth_from_peak(mapStr2intVec& IntFeatureData,
 int LibV5::AHP1_depth_from_peak(mapStr2intVec& IntFeatureData,
                                 mapStr2doubleVec& DoubleFeatureData,
                                 mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "AHP1_depth_from_peak", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> ahpDepthFromPeak, ahp1DepthFromPeak;
   retVal = getVec(DoubleFeatureData, StringData, "AHP_depth_from_peak",
                         ahpDepthFromPeak);
@@ -1288,11 +1160,7 @@ int LibV5::AHP1_depth_from_peak(mapStr2intVec& IntFeatureData,
 int LibV5::AHP2_depth_from_peak(mapStr2intVec& IntFeatureData,
                                 mapStr2doubleVec& DoubleFeatureData,
                                 mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "AHP2_depth_from_peak", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> ahpDepthFromPeak, ahp2DepthFromPeak;
   retVal = getVec(DoubleFeatureData, StringData, "AHP_depth_from_peak",
                         ahpDepthFromPeak);
@@ -1361,11 +1229,7 @@ static int __AP_begin_width(const vector<double>& t, const vector<double>& v,
 int LibV5::AP_begin_width(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "AP_begin_width", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<int> AP_begin_indices, minAHPIndex;
   vector<double> V, t, dv1, dv2, AP_begin_width;
   vector<double> stim_start;
@@ -1410,11 +1274,7 @@ static int __AP_begin_time(const vector<double>& t, const vector<double>& v,
 int LibV5::AP_begin_time(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "AP_begin_time", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<int> AP_begin_indices;
   vector<double> V, t, AP_begin_time;
   retVal = getVec(DoubleFeatureData, StringData, "V", V);
@@ -1444,11 +1304,7 @@ static int __AP_begin_voltage(const vector<double>& t, const vector<double>& v,
 int LibV5::AP_begin_voltage(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP_begin_voltage",
-                            nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<int> AP_begin_indices;
   vector<double> V, t, AP_begin_voltage;
   retVal = getVec(DoubleFeatureData, StringData, "V", V);
@@ -1470,11 +1326,7 @@ int LibV5::AP_begin_voltage(mapStr2intVec& IntFeatureData,
 int LibV5::AP1_begin_voltage(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP1_begin_voltage",
-                            nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> AP_begin_voltage, AP1_begin_voltage;
   retVal = getVec(DoubleFeatureData, StringData, "AP_begin_voltage",
                         AP_begin_voltage);
@@ -1493,11 +1345,7 @@ int LibV5::AP1_begin_voltage(mapStr2intVec& IntFeatureData,
 int LibV5::AP2_begin_voltage(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP2_begin_voltage",
-                            nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> AP_begin_voltage, AP2_begin_voltage;
   retVal = getVec(DoubleFeatureData, StringData, "AP_begin_voltage",
                         AP_begin_voltage);
@@ -1516,11 +1364,7 @@ int LibV5::AP2_begin_voltage(mapStr2intVec& IntFeatureData,
 int LibV5::AP1_begin_width(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "AP1_begin_width", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> AP_begin_width, AP1_begin_width;
   retVal = getVec(DoubleFeatureData, StringData, "AP_begin_width",
                         AP_begin_width);
@@ -1539,11 +1383,7 @@ int LibV5::AP1_begin_width(mapStr2intVec& IntFeatureData,
 int LibV5::AP2_begin_width(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "AP2_begin_width", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> AP_begin_width, AP2_begin_width;
   retVal = getVec(DoubleFeatureData, StringData, "AP_begin_width",
                         AP_begin_width);
@@ -1563,11 +1403,7 @@ int LibV5::AP2_begin_width(mapStr2intVec& IntFeatureData,
 int LibV5::AP2_AP1_begin_width_diff(mapStr2intVec& IntFeatureData,
                                     mapStr2doubleVec& DoubleFeatureData,
                                     mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "AP2_AP1_begin_width_diff", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> AP_begin_widths, AP2_AP1_begin_width_diff;
   retVal = getVec(DoubleFeatureData, StringData, "AP_begin_width",
                         AP_begin_widths);
@@ -1625,11 +1461,6 @@ int LibV5::voltage_deflection_begin(mapStr2intVec& IntFeatureData,
                                     mapStr2doubleVec& DoubleFeatureData,
                                     mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "voltage_deflection_begin", nSize);
-  if (retVal) return nSize;
-
   vector<double> v;
   vector<double> t;
   vector<double> stimStart;
@@ -1659,10 +1490,6 @@ int LibV5::is_not_stuck(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
   int retval;
-  int size;
-  retval = CheckInMap(IntFeatureData, StringData, "is_not_stuck", size);
-  if (retval) return size;
-
   vector<double> peak_time;
   vector<double> stim_start;
   vector<double> stim_end;
@@ -1696,11 +1523,7 @@ int LibV5::is_not_stuck(mapStr2intVec& IntFeatureData,
 int LibV5::voltage_after_stim(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "voltage_after_stim",
-                            nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> v, t, stimEnd, vRest;
   double startTime, endTime;
   retVal = getVec(DoubleFeatureData, StringData, "V", v);
@@ -1731,11 +1554,7 @@ int LibV5::voltage_after_stim(mapStr2intVec& IntFeatureData,
 int LibV5::mean_AP_amplitude(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "mean_AP_amplitude",
-                            nSize);
-  if (retVal > 0) return nSize;
-
+  int retVal;
   vector<double> AP_amplitude;
   retVal =
       getVec(DoubleFeatureData, StringData, "AP_amplitude", AP_amplitude);
@@ -1772,11 +1591,6 @@ int LibV5::BPAPHeightLoc1(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "BPAPHeightLoc1", nsize);
-  if (retval) return nsize;
-
   vector<double> peakvoltage;
   retval = getDoubleParam(DoubleFeatureData, "peak_voltage;location_dend1",
                           peakvoltage);
@@ -1812,11 +1626,6 @@ int LibV5::BPAPAmplitudeLoc1(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "BPAPAmplitudeLoc1",
-                            nsize);
-  if (retval) return nsize;
-
   vector<double> peakvoltage;
   retval = getDoubleParam(DoubleFeatureData, "peak_voltage;location_dend1",
                           peakvoltage);
@@ -1851,11 +1660,6 @@ int LibV5::BPAPAmplitudeLoc2(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "BPAPAmplitudeLoc2",
-                            nsize);
-  if (retval) return nsize;
-
   vector<double> peakvoltage;
   retval = getDoubleParam(DoubleFeatureData, "peak_voltage;location_dend2",
                           peakvoltage);
@@ -1890,11 +1694,6 @@ int LibV5::BPAPHeightLoc2(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval =
-      CheckInMap(DoubleFeatureData, StringData, "BPAPHeightLoc2", nsize);
-  if (retval) return nsize;
-
   vector<double> peakvoltage;
   retval = getDoubleParam(DoubleFeatureData, "peak_voltage;location_dend2",
                           peakvoltage);
@@ -1929,15 +1728,6 @@ int LibV5::check_AISInitiation(mapStr2intVec& IntFeatureData,
                                mapStr2doubleVec& DoubleFeatureData,
                                mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  // printf("Started check_AISInitation\n");
-
-  retval = CheckInMap(DoubleFeatureData, StringData,
-                            "check_AISInitiation", nsize);
-  if (retval) return nsize;
-
-  // printf("Starting AP_begin_time\n");
-
   vector<double> apBeginSoma;
   retval = getDoubleParam(DoubleFeatureData, "AP_begin_time", apBeginSoma);
   if (retval <= 0) {
@@ -2021,11 +1811,6 @@ int LibV5::AP_phaseslope(mapStr2intVec& IntFeatureData,
                          mapStr2doubleVec& DoubleFeatureData,
                          mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "AP_phaseslope", nSize);
-  if (retVal) return nSize;
-
   vector<double> v;
   retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
@@ -2067,11 +1852,6 @@ int LibV5::AP_phaseslope_AIS(mapStr2intVec& IntFeatureData,
                              mapStr2doubleVec& DoubleFeatureData,
                              mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "AP_phaseslope_AIS",
-                            nSize);
-  if (retVal) return nSize;
-
   vector<double> ap_phaseslopes;
   retVal = getVec(DoubleFeatureData, StringData,
                         "AP_phaseslope;location_AIS", ap_phaseslopes);
@@ -2085,10 +1865,6 @@ int LibV5::BAC_width(mapStr2intVec& IntFeatureData,
                      mapStr2doubleVec& DoubleFeatureData,
                      mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "BAC_width", nSize);
-  if (retVal) return nSize;
-
   vector<double> ap_width;
   retVal = getVec(DoubleFeatureData, StringData, "AP_width;location_epsp",
                         ap_width);
@@ -2110,11 +1886,6 @@ int LibV5::BAC_maximum_voltage(mapStr2intVec& IntFeatureData,
                                mapStr2doubleVec& DoubleFeatureData,
                                mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "BAC_maximum_voltage", nSize);
-  if (retVal) return nSize;
-
   vector<double> ap_phaseslopes;
   retVal = getVec(DoubleFeatureData, StringData,
                         "maximum_voltage;location_epsp", ap_phaseslopes);
@@ -2128,11 +1899,7 @@ int LibV5::BAC_maximum_voltage(mapStr2intVec& IntFeatureData,
 int LibV5::all_ISI_values(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "all_ISI_values", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> VecISI, pvTime;
   retVal = getVec(DoubleFeatureData, StringData, "peak_time", pvTime);
   if (retVal < 2) {
@@ -2150,11 +1917,7 @@ int LibV5::all_ISI_values(mapStr2intVec& IntFeatureData,
 int LibV5::AP_amplitude_from_voltagebase(mapStr2intVec& IntFeatureData,
                                          mapStr2doubleVec& DoubleFeatureData,
                                          mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "AP_amplitude_from_voltagebase", nSize);
-  if (retVal > 0) return nSize;
-
+  int retVal;
   vector<double> peakvoltage;
   vector<double> voltage_base_vec;
   double voltage_base;
@@ -2189,11 +1952,7 @@ int LibV5::AP_amplitude_from_voltagebase(mapStr2intVec& IntFeatureData,
 int LibV5::min_voltage_between_spikes(mapStr2intVec& IntFeatureData,
                                       mapStr2doubleVec& DoubleFeatureData,
                                       mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "min_voltage_between_spikes", nSize);
-  if (retVal > 0) return nSize;
-
+  int retVal;
   vector<int> peak_indices;
   vector<double> v;
   vector<double> min_voltage_between_spikes;
@@ -2227,10 +1986,7 @@ int LibV5::min_voltage_between_spikes(mapStr2intVec& IntFeatureData,
 int LibV5::voltage(mapStr2intVec& IntFeatureData,
                    mapStr2doubleVec& DoubleFeatureData,
                    mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "voltage", nSize);
-  if (retVal > 0) return nSize;
-
+  int retVal;
   vector<double> v;
   retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) {
@@ -2246,10 +2002,7 @@ int LibV5::voltage(mapStr2intVec& IntFeatureData,
 int LibV5::current(mapStr2intVec& IntFeatureData,
                    mapStr2doubleVec& DoubleFeatureData,
                    mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "current", nSize);
-  if (retVal > 0) return nSize;
-
+  int retVal;
   vector<double> i;
   retVal = getVec(DoubleFeatureData, StringData, "I", i);
   if (retVal < 0) {
@@ -2265,10 +2018,7 @@ int LibV5::current(mapStr2intVec& IntFeatureData,
 int LibV5::time(mapStr2intVec& IntFeatureData,
                    mapStr2doubleVec& DoubleFeatureData,
                    mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData, "time", nSize);
-  if (retVal > 0) return nSize;
-
+  int retVal;
   vector<double> t;
   retVal = getVec(DoubleFeatureData, StringData, "T", t);
   if (retVal < 0) {
@@ -2285,15 +2035,7 @@ int LibV5::steady_state_voltage_stimend(mapStr2intVec& IntFeatureData,
                                         mapStr2doubleVec& DoubleFeatureData,
                                         mapStr2Str& StringData) {
   int retVal;
-  int nSize;
   vector<double> t, v, stimEnd, stimStart, ssv;
-
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "steady_state_voltage_stimend", nSize);
-  if (retVal) {
-    return nSize;
-  }
-
   retVal = getVec(DoubleFeatureData, StringData, "V", v);
   if (retVal < 0) return -1;
   retVal = getVec(DoubleFeatureData, StringData, "T", t);
@@ -2337,11 +2079,7 @@ int LibV5::steady_state_voltage_stimend(mapStr2intVec& IntFeatureData,
 int LibV5::voltage_base(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "voltage_base", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<double> v, t, stimStart, vRest, vb_start_perc_vec, vb_end_perc_vec;
   double startTime, endTime, vb_start_perc, vb_end_perc;
   retVal = getVec(DoubleFeatureData, StringData, "V", v);
@@ -2416,11 +2154,7 @@ int LibV5::current_base(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
 
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "current_base", nSize);
-  if (retVal) return nSize;                      
-
+  int retVal;         
   vector<double> i, t, stimStart, iRest, cb_start_perc_vec, cb_end_perc_vec;
   double startTime, endTime, cb_start_perc, cb_end_perc;
   retVal = getVec(DoubleFeatureData, StringData, "I", i);
@@ -2543,14 +2277,6 @@ int LibV5::decay_time_constant_after_stim(mapStr2intVec& IntFeatureData,
                                           mapStr2doubleVec& DoubleFeatureData,
                                           mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "decay_time_constant_after_stim", nSize);
-  if (retVal) {
-    return nSize;
-  }
-
   vector<double> voltages;
   retVal = getVec(DoubleFeatureData, StringData, "V", voltages);
   if (retVal < 0) return -1;
@@ -2610,14 +2336,6 @@ int LibV5::multiple_decay_time_constant_after_stim(mapStr2intVec& IntFeatureData
                                              mapStr2doubleVec& DoubleFeatureData,
                                              mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "multiple_decay_time_constant_after_stim", nSize);
-  if (retVal) {
-    return nSize;
-  }
-
   vector<double> voltages;
   retVal = getVec(DoubleFeatureData, StringData, "V", voltages);
   if (retVal < 0) return -1;
@@ -2733,14 +2451,6 @@ int LibV5::sag_time_constant(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "sag_time_constant", nSize);
-  if (retVal) {
-    return nSize;
-  }
-
   vector<double> voltages;
   retVal = getVec(DoubleFeatureData, StringData, "V", voltages);
   if (retVal < 0) return -1;
@@ -2798,11 +2508,6 @@ int LibV5::voltage_deflection_vb_ssse(mapStr2intVec& IntFeatureData,
                                       mapStr2doubleVec& DoubleFeatureData,
                                       mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "voltage_deflection_vb_ssse", nSize);
-  if (retVal) return nSize;
-
   vector<double> voltage_base;
   retVal =
       getVec(DoubleFeatureData, StringData, "voltage_base", voltage_base);
@@ -2832,11 +2537,6 @@ int LibV5::ohmic_input_resistance_vb_ssse(mapStr2intVec& IntFeatureData,
                                           mapStr2doubleVec& DoubleFeatureData,
                                           mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "ohmic_input_resistance_vb_ssse", nSize);
-  if (retVal) return nSize;
-
   vector<double> voltage_deflection_vb_ssse;
   retVal =
       getVec(DoubleFeatureData, StringData, "voltage_deflection_vb_ssse",
@@ -2863,11 +2563,6 @@ int LibV5::maximum_voltage_from_voltagebase(mapStr2intVec& IntFeatureData,
                                             mapStr2doubleVec& DoubleFeatureData,
                                             mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "maximum_voltage_from_voltagebase", nSize);
-  if (retVal) return nSize;
-
   vector<double> maximum_voltage;
   retVal = getVec(DoubleFeatureData, StringData, "maximum_voltage",
                         maximum_voltage);
@@ -2905,14 +2600,7 @@ int LibV5::Spikecount_stimint(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
   int retval;
-  int nsize;
   int spikecount_stimint_value;
-  retval =
-      CheckInMap(IntFeatureData, StringData, "Spikecount_stimint", nsize);
-  if (retval) {
-    return nsize;
-  }
-
   // Get stimulus start
   vector<double> stimstart;
   retval = getVec(DoubleFeatureData, StringData, "stim_start", stimstart);
@@ -3020,11 +2708,7 @@ static int __peak_indices(double threshold, vector<double>& V,
 int LibV5::peak_indices(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
-  int retVal, nSize;
-
-  retVal = CheckInMap(IntFeatureData, StringData, "peak_indices", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   vector<int> PeakIndex, strict_stiminterval_vec;
   vector<double> v, t, threshold, stim_start_vec, stim_end_vec;
   bool strict_stiminterval = false;
@@ -3082,11 +2766,6 @@ int LibV5::sag_amplitude(mapStr2intVec& IntFeatureData,
                                           mapStr2doubleVec& DoubleFeatureData,
                                           mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "sag_amplitude", nSize);
-  if (retVal) return nSize;
-
   // Get steady_state_voltage_stimend
   vector<double> steady_state_voltage_stimend;
   retVal =
@@ -3136,11 +2815,6 @@ int LibV5::sag_ratio1(mapStr2intVec& IntFeatureData,
                                           mapStr2doubleVec& DoubleFeatureData,
                                           mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "sag_ratio1", nSize);
-  if (retVal) return nSize;
-
   // Get sag_amplitude
   vector<double> sag_amplitude;
   retVal =
@@ -3184,11 +2858,6 @@ int LibV5::sag_ratio2(mapStr2intVec& IntFeatureData,
                                           mapStr2doubleVec& DoubleFeatureData,
                                           mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "sag_ratio2", nSize);
-  if (retVal) return nSize;
-
   // Get voltage_base
   vector<double> voltage_base;
   retVal =
@@ -3269,14 +2938,6 @@ int LibV5::AP_peak_upstroke(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-
-  // Check if calculated already
-  retVal = CheckInMap(IntFeatureData, StringData, "AP_peak_upstroke", nSize);
-  if (retVal) {
-    return nSize;
-  }
-
   // Get input parameters
   vector<double> t;
   retVal = getVec(DoubleFeatureData, StringData, "T", t);
@@ -3331,14 +2992,6 @@ int LibV5::AP_peak_downstroke(mapStr2intVec& IntFeatureData,
                             mapStr2doubleVec& DoubleFeatureData,
                             mapStr2Str& StringData) {
   int retVal;
-  int nSize;
-
-  // Check if calculated already
-  retVal = CheckInMap(IntFeatureData, StringData, "AP_peak_downstroke", nSize);
-  if (retVal) {
-    return nSize;
-  }
-
   // Get input parameters
   vector<double> t;
   retVal = getVec(DoubleFeatureData, StringData, "T", t);
@@ -3411,11 +3064,7 @@ static int __min_between_peaks_indices(const vector<double>& t, const vector<dou
 int LibV5::min_between_peaks_indices(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
-  int retVal, nSize;
-
-  retVal = CheckInMap(IntFeatureData, StringData, "min_between_peaks_indices", nSize);
-  if (retVal) return nSize;
-
+  int retVal;
   double stim_start, stim_end;
   vector<int> min_btw_peaks_indices, strict_stiminterval_vec, peak_indices;
   vector<double> v, t, stim_start_vec, stim_end_vec, min_btw_peaks_values;
@@ -3483,11 +3132,7 @@ int LibV5::min_between_peaks_indices(mapStr2intVec& IntFeatureData,
 int LibV5::min_between_peaks_values(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "min_between_peaks_values", nSize);
-  if (retVal) return nSize;
-  return -1;
+  return 1;
 }
 
 
@@ -3525,13 +3170,6 @@ int LibV5::AP_width_between_threshold(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
   int retval;
-  int nsize;
-  retval = CheckInMap(DoubleFeatureData, StringData, "AP_width_between_threshold",
-                            nsize);
-  if (retval) {
-    return nsize;
-  }
-
   vector<double> t;
   retval = getVec(DoubleFeatureData, StringData, "T", t);
   if (retval < 0) return -1;
@@ -3617,13 +3255,6 @@ int LibV5::burst_begin_indices(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
   int retVal;
-  int nsize;
-  retVal = CheckInMap(IntFeatureData, StringData, "burst_begin_indices",
-                            nsize);
-  if (retVal) {
-    return nsize;
-  }
-
   vector<int> burst_begin_indices, burst_end_indices, retIgnore;
   vector<double> ISI_values, tVec;
   int IgnoreFirstISI;
@@ -3661,11 +3292,8 @@ int LibV5::burst_begin_indices(mapStr2intVec& IntFeatureData,
 int LibV5::burst_end_indices(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(IntFeatureData, StringData, "burst_end_indices", nSize);
-  if (retVal) return nSize;
-  return -1;
+  int retVal;
+  return 1;
 }
 
 
@@ -3690,12 +3318,7 @@ static int __strict_burst_mean_freq(vector<double>& PVTime,
 int LibV5::strict_burst_mean_freq(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "strict_burst_mean_freq", nSize);
-  if (retVal)
-    return nSize;
-
+  int retVal;
   vector<int> burst_begin_indices, burst_end_indices;
   vector<double> BurstMeanFreq, PVTime;
   retVal = getVec(DoubleFeatureData, StringData, "peak_time", PVTime);
@@ -3719,12 +3342,7 @@ int LibV5::strict_burst_mean_freq(mapStr2intVec& IntFeatureData,
 int LibV5::strict_burst_number(mapStr2intVec& IntFeatureData,
                         mapStr2doubleVec& DoubleFeatureData,
                         mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(IntFeatureData, StringData, "strict_burst_number", nSize);
-  if (retVal)
-    return nSize;
-
+  int retVal;
   vector<double> BurstMeanFreq;
   vector<int> BurstNum;
   retVal = getVec(DoubleFeatureData, StringData,
@@ -3772,12 +3390,7 @@ static int __strict_interburst_voltage(vector<int>& burst_begin_indices,
 int LibV5::strict_interburst_voltage(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "strict_interburst_voltage", nSize);
-  if (retVal)
-    return nSize;
-
+  int retVal;
   vector<int> burst_begin_indices, PeakIndex;
   vector<double> V, T, IBV;
   retVal = getVec(IntFeatureData, StringData, "peak_indices", PeakIndex);
@@ -3827,12 +3440,7 @@ static int __ADP_peak_indices(vector<double>& v,
 int LibV5::ADP_peak_indices(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(IntFeatureData, StringData,
-                            "ADP_peak_indices", nSize);
-  if (retVal)
-    return nSize;
-
+  int retVal;
   vector<int> min_AHP_indices, min_between_peaks_indices, ADP_peak_indices;
   vector<double> ADP_peak_values, v;
   retVal = getVec(DoubleFeatureData, StringData, "V", v);
@@ -3859,11 +3467,7 @@ int LibV5::ADP_peak_indices(mapStr2intVec& IntFeatureData,
 int LibV5::ADP_peak_values(mapStr2intVec& IntFeatureData,
                           mapStr2doubleVec& DoubleFeatureData,
                           mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "ADP_peak_values", nSize);
-  if (retVal) return nSize;
-  return -1;
+  return 1;
 }
 
 
@@ -3871,12 +3475,7 @@ int LibV5::ADP_peak_values(mapStr2intVec& IntFeatureData,
 int LibV5::ADP_peak_amplitude(mapStr2intVec& IntFeatureData,
                            mapStr2doubleVec& DoubleFeatureData,
                            mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "ADP_peak_amplitude", nSize);
-  if (retVal)
-    return nSize;
-
+  int retVal;
   vector<double> ADP_peak_amplitude, min_AHP_values, ADP_peak_values;
   retVal = getVec(DoubleFeatureData, StringData, "min_AHP_values",
                   min_AHP_values);
@@ -3919,12 +3518,7 @@ static int __interburst_min_indices(vector<double>& v,
 int LibV5::interburst_min_indices(mapStr2intVec& IntFeatureData,
                                   mapStr2doubleVec& DoubleFeatureData,
                                   mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(IntFeatureData, StringData,
-                      "interburst_min_indices", nSize);
-  if (retVal)
-    return nSize;
-
+  int retVal;
   vector<int> peak_indices, burst_end_indices, interburst_min_indices;
   vector<double> interburst_min_values, v;
   retVal = getVec(DoubleFeatureData, StringData, "V", v);
@@ -3951,11 +3545,7 @@ int LibV5::interburst_min_indices(mapStr2intVec& IntFeatureData,
 int LibV5::interburst_min_values(mapStr2intVec& IntFeatureData,
                                  mapStr2doubleVec& DoubleFeatureData,
                                  mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "interburst_min_values", nSize);
-  if (retVal >= 0) return nSize;
-  return -1;
+  return 1;
 }
 
 
@@ -4000,12 +3590,7 @@ static int __postburst_min_indices(vector<double>& t,
 int LibV5::postburst_min_indices(mapStr2intVec& IntFeatureData,
                                   mapStr2doubleVec& DoubleFeatureData,
                                   mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(IntFeatureData, StringData,
-                      "postburst_min_indices", nSize);
-  if (retVal)
-    return nSize;
-
+  int retVal;
   double stim_end;
   vector<int> peak_indices, burst_end_indices, postburst_min_indices;
   vector<double> postburst_min_values, t, v, stim_end_vec;
@@ -4043,23 +3628,14 @@ int LibV5::postburst_min_indices(mapStr2intVec& IntFeatureData,
 int LibV5::postburst_min_values(mapStr2intVec& IntFeatureData,
                                  mapStr2doubleVec& DoubleFeatureData,
                                  mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal =
-      CheckInMap(DoubleFeatureData, StringData, "postburst_min_values", nSize);
-  if (retVal >= 0) return nSize;
-  return -1;
+  return 1;
 }
 
 
 int LibV5::time_to_interburst_min(mapStr2intVec& IntFeatureData,
                                   mapStr2doubleVec& DoubleFeatureData,
                                   mapStr2Str& StringData) {
-  int retVal, nSize;
-  retVal = CheckInMap(DoubleFeatureData, StringData,
-                            "time_to_interburst_min", nSize);
-  if (retVal)
-    return nSize;
-
+  int retVal;
   vector<double> time_to_interburst_min, peak_time, time;
   vector<int> interburst_min_indices, burst_end_indices;
   retVal = getVec(DoubleFeatureData, StringData, "T",

--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -114,7 +114,7 @@ int LibV5::ISI_semilog_slope(mapStr2intVec& IntFeatureData,
 int LibV5::ISI_log_slope_skip(mapStr2intVec& IntFeatureData,
                               mapStr2doubleVec& DoubleFeatureData,
                               mapStr2Str& StringData) {
-  int size, retVal;
+  int retVal;
   vector<int> maxnSpike;
   vector<double> spikeSkipf;
 
@@ -876,7 +876,6 @@ int LibV5::AP1_amp(mapStr2intVec& IntFeatureData,
 int LibV5::APlast_amp(mapStr2intVec& IntFeatureData,
                       mapStr2doubleVec& DoubleFeatureData,
                       mapStr2Str& StringData) {
-  int retVal;
   vector<double> AP_amplitudes, APlast_amp;
   int AP_amplitude_size;
 
@@ -3292,7 +3291,6 @@ int LibV5::burst_begin_indices(mapStr2intVec& IntFeatureData,
 int LibV5::burst_end_indices(mapStr2intVec& IntFeatureData,
                     mapStr2doubleVec& DoubleFeatureData,
                     mapStr2Str& StringData) {
-  int retVal;
   return 1;
 }
 

--- a/efel/cppcore/cfeature.cpp
+++ b/efel/cppcore/cfeature.cpp
@@ -57,6 +57,23 @@ cFeature::cFeature(const string& strDepFile, const string& outdir)
   logger << "Using dependency file: " << strDepFile << endl;
 }
 
+template <typename T>
+const vector<T> cFeature::getMapData(const string& strName, const map<string, vector<T>>& mapData) {
+    auto mapItr = mapData.find(strName);
+    if (mapItr == mapData.end()) {
+        return vector<T>{}; // Return an empty vector without modifying the map
+    }
+    return mapItr->second;
+}
+
+const vector<int> cFeature::getmapIntData(string strName) {
+    return getMapData(strName, mapIntData);
+}
+
+const vector<double> cFeature::getmapDoubleData(string strName) {
+    return getMapData(strName, mapDoubleData);
+}
+
 int cFeature::setVersion(string strDepFile) {
   FptrTable.clear();
   /*

--- a/efel/cppcore/cfeature.cpp
+++ b/efel/cppcore/cfeature.cpp
@@ -280,29 +280,6 @@ void cFeature::get_feature_names(vector<string>& feature_names) {
   }
 }
 
-vector<int>& cFeature::getmapIntData(string strName) {
-  map<string, vector<int> >::iterator mapstr2IntItr;
-  mapstr2IntItr = mapIntData.find(strName);
-  if (mapstr2IntItr == mapIntData.end()) {
-    GErrorStr += "Feature [" + strName + "] data is missing\n";
-    vector<int> empty_vec;
-    mapIntData[strName] = empty_vec;
-    return mapIntData[strName];
-  }
-  return mapstr2IntItr->second;
-}
-vector<double>& cFeature::getmapDoubleData(string strName) {
-  map<string, vector<double> >::iterator mapstr2DoubleItr;
-  mapstr2DoubleItr = mapDoubleData.find(strName);
-  if (mapstr2DoubleItr == mapDoubleData.end()) {
-    GErrorStr += "Feature [" + strName + "] data is missing\n";
-    vector<double> empty_vec;
-    mapDoubleData[strName] = empty_vec;
-    return mapDoubleData[strName];
-  }
-  return mapstr2DoubleItr->second;
-}
-
 /*
 int cFeature::getmapfptrVec(string strName, vector<fptr> &vFptr){
     map<string, vector< fptr > >::iterator mapFptrItr;
@@ -450,7 +427,7 @@ int cFeature::getFeatureInt(string strName, vector<int>& vec) {
               << endl;
     return -1;
   }
-  vec = getmapIntData(strName);
+  vec = cFeature::getmapIntData(strName);
 
   logger << "Calculated feature " << strName << ":" << vec << endl;
 

--- a/efel/cppcore/cfeature.cpp
+++ b/efel/cppcore/cfeature.cpp
@@ -421,31 +421,57 @@ int cFeature::calc_features(const string& name) {
 }
 
 int cFeature::getFeatureInt(string strName, vector<int>& vec) {
-  logger << "Going to calculate feature " << strName << " ..." << endl;
-  if (calc_features(strName) < 0) {
-    logger << "Failed to calculate feature " << strName << ": " << GErrorStr
-              << endl;
-    return -1;
+  const auto& dataMap = mapIntData;
+  // 1) Check if the feature is in the map.
+  vec = getMapData<int>(strName, dataMap);
+  if (!vec.empty())
+  {
+    logger << "Reusing computed value of " << strName << "." << endl;
+    return vec.size();
   }
-  vec = cFeature::getmapIntData(strName);
+  else
+  {
+    // 2) If it's not in the map, compute.
+    logger << "Going to calculate feature " << strName << " ..." << endl;
+    if (calc_features(strName) < 0) {
+      logger << "Failed to calculate feature " << strName << ": " << GErrorStr << endl;
+      return -1;
+    }
+    vec = getMapData<int>(strName, dataMap);
+    if (vec.empty())
+      GErrorStr += "Feature [" + strName + "] data is missing\n";
 
-  logger << "Calculated feature " << strName << ":" << vec << endl;
+    logger << "Calculated feature " << strName << ":" << vec << endl;
 
-  return vec.size();
+    return vec.size();
+  }
 }
 
 int cFeature::getFeatureDouble(string strName, vector<double>& vec) {
-  logger << "Going to calculate feature " << strName << " ..." << endl;
-  if (calc_features(strName) < 0) {
-    logger << "Failed to calculate feature " << strName << ": " << GErrorStr
-              << endl;
-    return -1;
+  const auto& dataMap = mapDoubleData;
+  // 1) Check if the feature is in the map.
+  vec = getMapData<double>(strName, dataMap);
+  if (!vec.empty())
+  {
+    logger << "Reusing computed value of " << strName << "." << endl;
+    return vec.size();
   }
-  vec = getmapDoubleData(strName);
+  else
+  {
+    // 2) If it's not in the map, compute.
+    logger << "Going to calculate feature " << strName << " ..." << endl;
+    if (calc_features(strName) < 0) {
+      logger << "Failed to calculate feature " << strName << ": " << GErrorStr << endl;
+      return -1;
+    }
+    vec = getMapData<double>(strName, dataMap);
+    if (vec.empty())
+      GErrorStr += "Feature [" + strName + "] data is missing\n";
 
-  logger << "Calculated feature " << strName << ":" << vec << endl;
+    logger << "Calculated feature " << strName << ":" << vec << endl;
 
-  return vec.size();
+    return vec.size();
+  }
 }
 
 int cFeature::setFeatureString(const string& key, const string& value) {

--- a/efel/cppcore/cfeature.h
+++ b/efel/cppcore/cfeature.h
@@ -46,21 +46,19 @@ class cFeature {
   std::map<string, vector<featureStringPair > > fptrlookup;
 
   template <typename T>
-  vector<T>& getMapData(string strName, map<string, vector<T>>& mapData) {
+  const vector<T> getMapData(const string& strName, const map<string, vector<T>>& mapData) {
       auto mapItr = mapData.find(strName);
       if (mapItr == mapData.end()) {
-          GErrorStr += "Feature [" + strName + "] data is missing\n";
-          mapData[strName] = vector<T>{};
-          return mapData[strName];
+          return vector<T>{}; // Return an empty vector without modifying the map
       }
       return mapItr->second;
   }
 
-  vector<int>& getmapIntData(string strName) {
+  const vector<int> getmapIntData(string strName) {
       return getMapData(strName, mapIntData);
   }
 
-  vector<double>& getmapDoubleData(string strName) {
+  const vector<double> getmapDoubleData(string strName) {
       return getMapData(strName, mapDoubleData);
   }
 

--- a/efel/cppcore/cfeature.h
+++ b/efel/cppcore/cfeature.h
@@ -44,27 +44,13 @@ class cFeature {
 
  public:
   std::map<string, vector<featureStringPair > > fptrlookup;
-
-  template <typename T>
-  const vector<T> getMapData(const string& strName, const map<string, vector<T>>& mapData) {
-      auto mapItr = mapData.find(strName);
-      if (mapItr == mapData.end()) {
-          return vector<T>{}; // Return an empty vector without modifying the map
-      }
-      return mapItr->second;
-  }
-
-  const vector<int> getmapIntData(string strName) {
-      return getMapData(strName, mapIntData);
-  }
-
-  const vector<double> getmapDoubleData(string strName) {
-      return getMapData(strName, mapDoubleData);
-  }
-
   eFELLogger logger;
 
   cFeature(const string& depFile, const string& outdir);
+  template <typename T>
+  const vector<T> getMapData(const string& strName, const map<string, vector<T>>& mapData);
+  const vector<int> getmapIntData(string strName);
+  const vector<double> getmapDoubleData(string strName);
   int getmapfptrVec(string strName, vector<feature_function>& vFptr);
   int calc_features(const string& name);
   template <typename T>

--- a/efel/cppcore/cfeature.h
+++ b/efel/cppcore/cfeature.h
@@ -67,10 +67,10 @@ class cFeature {
   cFeature(const string& depFile, const string& outdir);
   int getmapfptrVec(string strName, vector<feature_function>& vFptr);
   int calc_features(const string& name);
+  template <typename T>
+  int getFeature(string strName, vector<T>& vec);
   int setFeatureInt(string strName, vector<int>& intVec);
-  int getFeatureInt(string strName, vector<int>& vec);
   int setFeatureDouble(string strName, vector<double>& DoubleVec);
-  int getFeatureDouble(string strName, vector<double>& vec);
   int setFeatureString(const string& key, const string& value);
   int getFeatureString(const string& key, string& value);
   void getTraces(const string& wildcard, vector<string>& traces);

--- a/efel/cppcore/cfeature.h
+++ b/efel/cppcore/cfeature.h
@@ -44,8 +44,25 @@ class cFeature {
 
  public:
   std::map<string, vector<featureStringPair > > fptrlookup;
-  vector<int>& getmapIntData(string strName);
-  vector<double>& getmapDoubleData(string strName);
+
+  template <typename T>
+  vector<T>& getMapData(string strName, map<string, vector<T>>& mapData) {
+      auto mapItr = mapData.find(strName);
+      if (mapItr == mapData.end()) {
+          GErrorStr += "Feature [" + strName + "] data is missing\n";
+          mapData[strName] = vector<T>{};
+          return mapData[strName];
+      }
+      return mapItr->second;
+  }
+
+  vector<int>& getmapIntData(string strName) {
+      return getMapData(strName, mapIntData);
+  }
+
+  vector<double>& getmapDoubleData(string strName) {
+      return getMapData(strName, mapDoubleData);
+  }
 
   eFELLogger logger;
 

--- a/efel/cppcore/cppcore.cpp
+++ b/efel/cppcore/cppcore.cpp
@@ -126,11 +126,11 @@ _getfeature(PyObject* self, PyObject* args, const string &type) {
 
   if (feature_type == "int") {
     vector<int> values;
-    return_value = pFeature->getFeatureInt(string(feature_name), values);
+    return_value = pFeature->getFeature<int>(string(feature_name), values);
     PyList_from_vectorint(values, py_values);
   } else if (feature_type == "double") {
     vector<double> values;
-    return_value = pFeature->getFeatureDouble(string(feature_name), values);
+    return_value = pFeature->getFeature<double>(string(feature_name), values);
     PyList_from_vectordouble(values, py_values);
   } else {
     PyErr_SetString(PyExc_TypeError, "Unknown feature name");

--- a/efel/cppcore/efel.cpp
+++ b/efel/cppcore/efel.cpp
@@ -68,7 +68,7 @@ int setFeatureDouble(const char *strName, double *A, unsigned nValue) {
 
 int getFeatureInt(const char *strName, int **A) {
   vector<int> vec;
-  if (pFeature->getFeatureInt(string(strName), vec) < 0) {
+  if (pFeature->getFeature<int>(string(strName), vec) < 0) {
     return -1;
   }
   *A = new int[vec.size()];
@@ -81,7 +81,7 @@ int getFeatureInt(const char *strName, int **A) {
 int getFeatureDouble(const char *strName, double **A) {
   vector<double> vec;
   // printf("\nInside featureLibrary.. Before getdouble [%s ]\n", strName);
-  if (pFeature->getFeatureDouble(string(strName), vec) < 0) {
+  if (pFeature->getFeature<double>(string(strName), vec) < 0) {
     return -1;
   }
   *A = new double[vec.size()];

--- a/efel/cppcore/mapoperations.cpp
+++ b/efel/cppcore/mapoperations.cpp
@@ -100,23 +100,6 @@ int getVec(std::map<std::string, std::vector<T> >& FeatureData, mapStr2Str& Stri
   return (v.size());
 }
 
-template <class T>
-int CheckInMap(std::map<std::string, std::vector<T> >& FeatureData,
-                     mapStr2Str& StringData, string strFeature, int& nSize){
-  string params;
-  getStrParam(StringData, "params", params);
-  strFeature += params;
-  typename std::map<std::string, std::vector<T> >::const_iterator
-   mapstr2VecItr(FeatureData.find(strFeature));
-
-  if (mapstr2VecItr != FeatureData.end()) {
-    nSize = mapstr2VecItr->second.size();
-    return 1;
-  }
-  nSize = -1;
-  return 0;
-}
-
 /*
  *  Take a wildcard string as an argument:
  *  wildcards seperated by ';' e.g. "APWaveForm;soma"
@@ -228,7 +211,3 @@ template int getVec(std::map<std::string, std::vector<double> >& FeatureData, ma
                  string strFeature, vector<double>& v);
 template int getVec(std::map<std::string, std::vector<int> >& FeatureData, mapStr2Str& StringData,
                  string strFeature, vector<int>& v);
-template int CheckInMap(std::map<std::string, std::vector<double> >& FeatureData,
-                     mapStr2Str& StringData, string strFeature, int& nSize);
-template int CheckInMap(std::map<std::string, std::vector<int> >& FeatureData,
-                     mapStr2Str& StringData, string strFeature, int& nSize);

--- a/efel/cppcore/mapoperations.h
+++ b/efel/cppcore/mapoperations.h
@@ -41,9 +41,6 @@ void setVec(std::map<std::string, std::vector<T> >& FeatureData, mapStr2Str& Str
 template <class T>
 int getVec(std::map<std::string, std::vector<T> >& FeatureData, mapStr2Str& StringData,
                  string strFeature, vector<T>& v);
-template <class T>
-int CheckInMap(std::map<std::string, std::vector<T> >& FeatureData,
-                     mapStr2Str& StringData, string strFeature, int& nSize);
 // eCode feature convenience function
 int mean_traces_double(mapStr2doubleVec& DoubleFeatureData,
                        const string& feature, const string& stimulus_name,

--- a/tests/test_cppcore.py
+++ b/tests/test_cppcore.py
@@ -45,7 +45,7 @@ def test_import():
     import efel.cppcore  # NOQA
 
 
-class TestCppcore(object):
+class TestCppcore:
 
     """Test cppcore"""
 
@@ -87,7 +87,7 @@ class TestCppcore(object):
 
     def test_getFeatureNames(self):  # pylint: disable=R0201
         """cppcore: Testing getting all feature names"""
-        import efel.cppcore
+        import efel
         feature_names = []
         efel.cppcore.getFeatureNames(feature_names)
 
@@ -101,7 +101,7 @@ class TestCppcore(object):
 
     def test_getFeatureDouble_failure(self):  # pylint: disable=R0201
         """cppcore: Testing failure exit code in getFeatureDouble"""
-        import efel.cppcore
+        import efel
         feature_values = list()
         return_value = efel.cppcore.getFeatureDouble(
             "AP_amplitude",
@@ -111,18 +111,18 @@ class TestCppcore(object):
     @pytest.mark.xfail(raises=TypeError)
     def test_getFeatureDouble_wrong_type(self):  # pylint: disable=R0201
         """cppcore: Teting getFeatureDouble with wrong type"""
-        import efel.cppcore
+        import efel
         efel.cppcore.getFeatureDouble("AP_fall_indices", list())
 
     @pytest.mark.xfail(raises=TypeError)
     def test_getFeatureInt_wrong_type(self):  # pylint: disable=R0201
         """cppcore: Teting getFeatureInt with wrong type"""
-        import efel.cppcore
+        import efel
         efel.cppcore.getFeatureInt("AP_amplitude", list())
 
     def test_getDistance(self):
         """cppcore: Testing getDistance()"""
-        import efel.cppcore
+        import efel
 
         self.setup_data()
         np.testing.assert_allclose(
@@ -135,7 +135,7 @@ class TestCppcore(object):
 
     def test_getFeature(self):
         """cppcore: Testing getFeature"""
-        import efel.cppcore
+        import efel
         self.setup_data()
 
         # get double feature
@@ -146,7 +146,6 @@ class TestCppcore(object):
         assert np.allclose([80.45724099440199, 80.46320199354948,
                             80.73300299176428, 80.9965359926715,
                             81.87292599493423], feature_values)
-
         # get int feature
         feature_values = list()
         efel.cppcore.getFeature('AP_fall_indices', feature_values)
@@ -156,7 +155,7 @@ class TestCppcore(object):
 
     def test_getFeature_failure(self):  # pylint: disable=R0201
         """cppcore: Testing failure exit code in getFeature"""
-        import efel.cppcore
+        import efel
         feature_values = list()
         return_value = efel.cppcore.getFeature("AP_amplitude", feature_values)
         assert return_value == -1
@@ -164,17 +163,16 @@ class TestCppcore(object):
     @pytest.mark.xfail(raises=TypeError)
     def test_getFeature_non_existant(self):  # pylint: disable=R0201
         """cppcore: Testing failure exit code in getFeature"""
-        import efel.cppcore
+        import efel
         efel.cppcore.getFeature("does_not_exist", list())
 
     def test_logging(self):  # pylint: disable=R0201
         """cppcore: Testing logging"""
         import efel
-        tempdir = tempfile.mkdtemp('efel_tests')
-        try:
+        with tempfile.TemporaryDirectory(prefix='efel_tests') as tempdir:
             efel.cppcore.Initialize(efel.getDependencyFileLocation(), tempdir)
             self.setup_data()
-            with open(os.path.join(tempdir, 'fllog.txt')) as fd:
+            with (Path(tempdir) / 'fllog.txt').open() as fd:
                 contents = fd.read()
                 assert 'Initializing' in contents
                 # test vector working (if more than 10 elements, prints ...

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ extras =
     neo
 usedevelop=True
 commands =
-    pycodestyle --ignore=E402,W503,W504 --exclude=_version.py efel tests
+    pycodestyle --ignore=E402,W503,W504 --exclude=_version.py --max-line-length=88 efel tests
     pytest -sx -n auto tests
 
 


### PR DESCRIPTION
Part of https://github.com/BlueBrain/eFEL/issues/321.

Memoization previously was done n_features times hence it was very hard to test.
There are ~150 C++ features. Each was performing a separate checking and retrieval of the cached results. Now there is only one implementation.
The responsibility of memoization is moved to cfeature. It became testable.
Does not introduce behavioural changes.
Scientists writing features (or reading them) do not have to worry about the underlying memoization mechanisms.
Uses C++17 for the `if constexpr (std::is_same_v<T, int>)` that allows conditional compilation of templates.

Note: CI image is updated to become ubuntu-22.04 since it uses gcc-11 by default. Otherwise we have to explicitly install gcc-11in each ci task. This change does not affect the users installing the wheels. They don't need to have a C++17 capable compiler. They'll be using the pre-compiled binaries we provide in the wheels.