### PR TITLE
bring efel to c++17 standard

### DIFF
--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -30,9 +30,6 @@
 #include <iomanip>
 
 using std::find_if;
-using std::greater;
-using std::greater_equal;
-using std::less_equal;
 using std::list;
 using std::min_element;
 using std::max_element;

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -29,7 +29,6 @@
 #include <sstream>
 #include <iomanip>
 
-using std::bind2nd;
 using std::find_if;
 using std::greater;
 using std::greater_equal;
@@ -378,7 +377,7 @@ static int __AHP_depth_abs_slow_indices(const vector<double>& t,
                 distance(t.begin(),
                          find_if(t.begin() + peakindices[i + 1],
                                  t.begin() + peakindices[i + 2],
-                                 bind2nd(greater_equal<double>(), t_start))),
+                                 [t_start](double val) { return val >= t_start; })),
             v.begin() + peakindices[i + 2]));
   }
   return adas_indices.size();
@@ -983,10 +982,11 @@ static int __time_constant(const vector<double>& v, const vector<double>& t,
   // int stimendindex;
   // for(stimendindex = 0; t[stimendindex] < stimEnd; stimendindex++) ;
   // int stimmiddleindex = (stimstartindex + stimendindex) / 2;
-  int stimmiddleindex = distance(
-      t.begin(),
-      find_if(t.begin() + stimstartindex, t.end(),
-              bind2nd(greater_equal<double>(), (stimStart + stimEnd) / 2.)));
+  double mid_stim = (stimStart + stimEnd) / 2.;
+  auto it_mid_stim = find_if(t.begin() + stimstartindex, t.end(),
+                            [mid_stim](double val) { return val >= mid_stim; });
+  int stimmiddleindex = distance(t.begin(), it_mid_stim);
+
   if (stimstartindex >= v.size() || stimmiddleindex < 0 ||
       static_cast<size_t>(stimmiddleindex) >= v.size()) {
     return -1;
@@ -1006,13 +1006,13 @@ static int __time_constant(const vector<double>& v, const vector<double>& t,
   // find start of the decay
   int i_start = 0;
   while (find_if(dvdt.begin() + i_start, dvdt.begin() + i_start + 5,
-                 bind2nd(greater<double>(), -min_derivative)) !=
-         dvdt.begin() + i_start + 5) {
-    if (dvdt.begin() + i_start + 5 == dvdt.end()) {
-      GErrorStr += "Could not find the decay.\n";
-      return -1;
-    }
-    i_start++;
+                [min_derivative](double val) { return val > -min_derivative; }) !=
+        dvdt.begin() + i_start + 5) {
+      if (dvdt.begin() + i_start + 5 == dvdt.end()) {
+        GErrorStr += "Could not find the decay.\n";
+        return -1;
+      }
+      i_start++;
   }
   // find the flat
   // bool foundflat = false;
@@ -1441,11 +1441,9 @@ static int __AP_width(const vector<double>& t, const vector<double>& v,
   if (strict_stiminterval){
     int start_index = distance(
         t.begin(),
-        find_if(t.begin(), t.end(), bind2nd(greater_equal<double>(), stimstart)));
-    int end_index =
-        distance(t.begin(),
-                 find_if(t.begin(), t.end(),
-                         std::bind2nd(std::greater_equal<double>(), stimend)));
+        find_if(t.begin(), t.end(), [stimstart](double x){ return x >= stimstart; }));
+    int end_index = distance(t.begin(), find_if(t.begin(), t.end(),
+      [stimend](double x){ return x >= stimend; }));
     indices.push_back(start_index);
     for (size_t i = 0; i < minahpindices.size(); i++) {
       if (start_index < minahpindices[i] && minahpindices[i] < end_index) {
@@ -1470,14 +1468,14 @@ static int __AP_width(const vector<double>& t, const vector<double>& v,
     v.begin() + indices[i + 1], bind2nd(less_equal<double>(), v_hm)));
     apwidth.push_back(t[hm_index2] - t[hm_index1]);
     */
-    int onset_index = distance(
-        v.begin(), find_if(v.begin() + indices[i], v.begin() + indices[i + 1],
-                           bind2nd(greater_equal<double>(), threshold)));
+    auto onset_index = std::distance(
+      v.begin(), std::find_if(v.begin() + indices[i], v.begin() + indices[i + 1],
+                 [threshold](double x){ return x >= threshold; }));
     // int end_index = distance(v.begin(), find_if(v.begin() + peakindices[i],
     // v.begin() + indices[i + 1], bind2nd(less_equal<double>(), threshold)));
-    int end_index = distance(
-        v.begin(), find_if(v.begin() + onset_index, v.begin() + indices[i + 1],
-                           bind2nd(less_equal<double>(), threshold)));
+    auto end_index = std::distance(
+      v.begin(), std::find_if(v.begin() + onset_index, v.begin() + indices[i + 1],
+                 [threshold](double x){ return x <= threshold; }));
     apwidth.push_back(t[end_index] - t[onset_index]);
   }
   return apwidth.size();

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -1004,13 +1004,13 @@ static int __time_constant(const vector<double>& v, const vector<double>& t,
   // find start of the decay
   int i_start = 0;
   while (find_if(dvdt.begin() + i_start, dvdt.begin() + i_start + 5,
-                [min_derivative](double val) { return val > -min_derivative; }) !=
-        dvdt.begin() + i_start + 5) {
-      if (dvdt.begin() + i_start + 5 == dvdt.end()) {
-        GErrorStr += "Could not find the decay.\n";
-        return -1;
-      }
-      i_start++;
+    [min_derivative](double val) { return val > -min_derivative; }) != dvdt.begin() + i_start + 5)
+  {
+    if (dvdt.begin() + i_start + 5 == dvdt.end()) {
+      GErrorStr += "Could not find the decay.\n";
+      return -1;
+    }
+    i_start++;
   }
   // find the flat
   // bool foundflat = false;

--- a/efel/cppcore/LibV1.cpp
+++ b/efel/cppcore/LibV1.cpp
@@ -29,6 +29,7 @@
 #include <sstream>
 #include <iomanip>
 
+using std::distance;
 using std::find_if;
 using std::list;
 using std::min_element;
@@ -1465,13 +1466,13 @@ static int __AP_width(const vector<double>& t, const vector<double>& v,
     v.begin() + indices[i + 1], bind2nd(less_equal<double>(), v_hm)));
     apwidth.push_back(t[hm_index2] - t[hm_index1]);
     */
-    auto onset_index = std::distance(
-      v.begin(), std::find_if(v.begin() + indices[i], v.begin() + indices[i + 1],
+    auto onset_index = distance(
+      v.begin(), find_if(v.begin() + indices[i], v.begin() + indices[i + 1],
                  [threshold](double x){ return x >= threshold; }));
     // int end_index = distance(v.begin(), find_if(v.begin() + peakindices[i],
     // v.begin() + indices[i + 1], bind2nd(less_equal<double>(), threshold)));
-    auto end_index = std::distance(
-      v.begin(), std::find_if(v.begin() + onset_index, v.begin() + indices[i + 1],
+    auto end_index = distance(
+      v.begin(), find_if(v.begin() + onset_index, v.begin() + indices[i + 1],
                  [threshold](double x){ return x <= threshold; }));
     apwidth.push_back(t[end_index] - t[onset_index]);
   }

--- a/efel/cppcore/LibV2.cpp
+++ b/efel/cppcore/LibV2.cpp
@@ -25,7 +25,6 @@
 #include <math.h>
 
 using std::find_if;
-using std::greater_equal;
 using std::min_element;
 using std::max_element;
 using std::transform;

--- a/efel/cppcore/LibV3.cpp
+++ b/efel/cppcore/LibV3.cpp
@@ -24,8 +24,6 @@
 #include <math.h>
 
 using std::find_if;
-using std::greater_equal;
-using std::less_equal;
 using std::list;
 using std::min_element;
 

--- a/efel/cppcore/LibV3.cpp
+++ b/efel/cppcore/LibV3.cpp
@@ -23,7 +23,6 @@
 #include <list>
 #include <math.h>
 
-using std::bind2nd;
 using std::find_if;
 using std::greater_equal;
 using std::less_equal;

--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -26,6 +26,9 @@
 #include <functional>
 #include <iterator>
 
+using std::distance;
+
+
 // slope of loglog of ISI curve
 static int __ISI_log_slope(const vector<double>& isiValues,
                            vector<double>& slope, bool skip, double spikeSkipf,
@@ -576,7 +579,7 @@ static int __AP_begin_indices(const vector<double>& t, const vector<double>& v,
 
   // restrict to time interval where stimulus is applied
   vector<int> minima, peak_indices;
-  auto stimbeginindex = std::distance(t.begin(),
+  auto stimbeginindex = distance(t.begin(),
       std::find_if(t.begin(), t.end(),
           [stimstart](double time){ return time >= stimstart; }));
   
@@ -723,11 +726,11 @@ static int __AP_end_indices(const vector<double>& t, const vector<double>& v,
   picopy.push_back(v.size() - 1);
 
   for (size_t i = 0; i < apei.size(); i++) {
-    max_slope = std::distance(
+    max_slope = distance(
         dvdt.begin(),
         std::min_element(dvdt.begin() + picopy[i] + 1, dvdt.begin() + picopy[i + 1]));
     // assure that the width of the slope is bigger than 4
-    apei[i] = std::distance(
+    apei[i] = distance(
         dvdt.begin(),
         std::find_if(dvdt.begin() + max_slope, dvdt.begin() + picopy[i + 1],
                 [derivativethreshold](double x){ return x >= derivativethreshold; }));
@@ -1195,7 +1198,7 @@ static int __AP_begin_width(const vector<double>& t, const vector<double>& v,
   auto it = std::find_if(t.begin(), t.end(), [stimstart](double val) {
     return val >= stimstart;
   });
-  int stimbeginindex = std::distance(t.begin(), it);
+  int stimbeginindex = distance(t.begin(), it);
   vector<int> strict_min_ahp_indices;
   for (size_t i = 0; i < min_ahp_indices.size(); i++) {
     if (min_ahp_indices[i] > stimbeginindex) {
@@ -2400,7 +2403,7 @@ static int __sag_time_constant(const vector<double>& times,
 
     // get start index
     const size_t decayStartIdx =
-      std::distance(voltage.begin(),
+      distance(voltage.begin(),
         std::find_if(voltage.begin(), voltage.end(),
             [minimum_voltage](double v){ return v <= minimum_voltage; }));
 
@@ -2409,7 +2412,7 @@ static int __sag_time_constant(const vector<double>& times,
     double steady_state_90 = steady_state_v - sag_amplitude * 0.1;
     // get end index
     const size_t decayEndIdx =
-      std::distance(voltage.begin(),
+      distance(voltage.begin(),
         std::find_if(voltage.begin() + decayStartIdx, voltage.end(),
             [steady_state_90](double v){ return v >= steady_state_90; }));
 

--- a/efel/cppcore/LibV5.cpp
+++ b/efel/cppcore/LibV5.cpp
@@ -27,6 +27,7 @@
 #include <iterator>
 
 using std::distance;
+using std::find_if;
 
 
 // slope of loglog of ISI curve
@@ -580,7 +581,7 @@ static int __AP_begin_indices(const vector<double>& t, const vector<double>& v,
   // restrict to time interval where stimulus is applied
   vector<int> minima, peak_indices;
   auto stimbeginindex = distance(t.begin(),
-      std::find_if(t.begin(), t.end(),
+      find_if(t.begin(), t.end(),
           [stimstart](double time){ return time >= stimstart; }));
   
   if (stimbeginindex > 1){
@@ -732,7 +733,7 @@ static int __AP_end_indices(const vector<double>& t, const vector<double>& v,
     // assure that the width of the slope is bigger than 4
     apei[i] = distance(
         dvdt.begin(),
-        std::find_if(dvdt.begin() + max_slope, dvdt.begin() + picopy[i + 1],
+        find_if(dvdt.begin() + max_slope, dvdt.begin() + picopy[i + 1],
                 [derivativethreshold](double x){ return x >= derivativethreshold; }));
   }
   return apei.size();
@@ -1195,7 +1196,7 @@ static int __AP_begin_width(const vector<double>& t, const vector<double>& v,
   // because AP_begin_indices are all after stim start
   // if not done, could cause cases where AP_begin_indices[i] > min_ahp_indices[i]
   // leading to segmentation faults
-  auto it = std::find_if(t.begin(), t.end(), [stimstart](double val) {
+  auto it = find_if(t.begin(), t.end(), [stimstart](double val) {
     return val >= stimstart;
   });
   int stimbeginindex = distance(t.begin(), it);
@@ -2404,7 +2405,7 @@ static int __sag_time_constant(const vector<double>& times,
     // get start index
     const size_t decayStartIdx =
       distance(voltage.begin(),
-        std::find_if(voltage.begin(), voltage.end(),
+        find_if(voltage.begin(), voltage.end(),
             [minimum_voltage](double v){ return v <= minimum_voltage; }));
 
 
@@ -2413,7 +2414,7 @@ static int __sag_time_constant(const vector<double>& times,
     // get end index
     const size_t decayEndIdx =
       distance(voltage.begin(),
-        std::find_if(voltage.begin() + decayStartIdx, voltage.end(),
+        find_if(voltage.begin() + decayStartIdx, voltage.end(),
             [steady_state_90](double v){ return v >= steady_state_90; }));
 
   // voltage reference by which the voltage (i the decay interval)

--- a/efel/cppcore/eFELLogger.h
+++ b/efel/cppcore/eFELLogger.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <string>
 
 class eFELLogger
 {
@@ -34,6 +35,13 @@ public:
       string filename = outdir + "/fllog.txt";
       logfile.open(filename.c_str(), std::fstream::out | std::fstream::app);
       logging = true;
+    }
+  }
+
+  ~eFELLogger() 
+  {
+    if (logfile.is_open()) {
+        logfile.close();
     }
   }
 

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ if os.environ.get('EFEL_COVERAGE_BUILD'):
 cppcore = Extension('efel.cppcore',
                     sources=cppcore_sources,
                     include_dirs=['efel/cppcore/'],
-                    extra_compile_args=coverage_flags,
+                    extra_compile_args=coverage_flags + ['-std=c++17'],
                     extra_link_args=coverage_flags)
 
 setup(

--- a/tests/test_cppcore.py
+++ b/tests/test_cppcore.py
@@ -200,6 +200,9 @@ class TestCppcore:
             efel.cppcore.getFeature(feature_name, feature_values)
             with (Path(tempdir) / 'fllog.txt').open() as fd:
                 contents = fd.read()
+            # re-call efel's Initialize with current dir to remove pointer to tempdir.
+            # this pointer was preventing the deletion of tempdir on windows.
+            efel.cppcore.Initialize(efel.getDependencyFileLocation(), '.')
         assert f"Calculated feature {feature_name}" in contents
         assert f"Reusing computed value of {feature_name}" in contents
         # make sure Calculated feature text occurs once


### PR DESCRIPTION
Changes:

* fixes linux, windows and mac wheel builds (previously failing)
* replace deprecated bind2nd with lambda
* add destructor to efel logger (to close the file once logger gets out of scope)