### PR TITLE
replace C++ exit(1) statements with exception handling

### DIFF
--- a/efel/cppcore/CMakeLists.txt
+++ b/efel/cppcore/CMakeLists.txt
@@ -40,6 +40,6 @@ add_library(efel SHARED ${FEATURESRCS})
 install(TARGETS efel LIBRARY DESTINATION lib)
 
 install(FILES efel.h cfeature.h FillFptrTable.h LibV1.h LibV2.h LibV3.h
-    LibV5.h mapoperations.h Utils.h DependencyTree.h eFELLogger.h
+    LibV5.h mapoperations.h Utils.h DependencyTree.h eFELLogger.h EfelExceptions.h
     types.h
     DESTINATION include)

--- a/efel/cppcore/EfelExceptions.h
+++ b/efel/cppcore/EfelExceptions.h
@@ -1,0 +1,12 @@
+#ifndef EFEL_EXCEPTIONS_H
+#define EFEL_EXCEPTIONS_H
+
+#include <stdexcept>
+
+// Define the custom exception class
+class EfelAssertionError : public std::runtime_error {
+public:
+  explicit EfelAssertionError(const std::string& message) : std::runtime_error(message) {}
+};
+
+#endif // EFEL_EXCEPTIONS_H

--- a/efel/cppcore/Utils.h
+++ b/efel/cppcore/Utils.h
@@ -26,6 +26,7 @@
 #include <numeric>
 #include <vector>
 #include <utility>
+#include "EfelExceptions.h"
 
 using std::vector;
 
@@ -85,8 +86,9 @@ inline void
 efel_assert(bool assertion, const char *message, const char *file, const int line)
 {
   if(!assertion){
-    printf("Assertion fired(%s:%d): %s\n", file, line, message);
-    exit(-1);
+    using std::string, std::to_string;
+    string errorMsg = "Assertion fired(" + string(file) + ":" + to_string(line) + "): " + string(message);
+    throw EfelAssertionError(errorMsg);
   }
 }
 

--- a/efel/cppcore/cfeature.cpp
+++ b/efel/cppcore/cfeature.cpp
@@ -627,10 +627,11 @@ string cFeature::featuretype(string featurename) {
   if (npos != string::npos) {
     featurename = featurename.substr(0, npos);
   }
+  if (featurename == "__test_efel_assertion__")  // for testing only
+    throw EfelAssertionError("Test efel assertion is successfully triggered.");
   string type = featuretypes[featurename];
-  if (type != "int" && type != "double") {
+  if (type != "int" && type != "double")
     throw std::runtime_error("Unknown feature name: " + featurename);
-  }
   return type;
 }
 

--- a/efel/cppcore/cfeature.cpp
+++ b/efel/cppcore/cfeature.cpp
@@ -374,9 +374,9 @@ int cFeature::calc_features(const string& name) {
   map<string, vector<featureStringPair> >::const_iterator lookup_it(
       fptrlookup.find(name));
   if (lookup_it == fptrlookup.end()) {
-      throw std::runtime_error("Feature dependency file entry or pointer table entry is missing.");
+    throw std::runtime_error("Feature dependency file entry or pointer table "
+                             "entry for '" + name + "' is missing.");
   }
-
   bool last_failed = false;
 
   for (vector<featureStringPair>::const_iterator pfptrstring =

--- a/efel/cppcore/cfeature.cpp
+++ b/efel/cppcore/cfeature.cpp
@@ -623,10 +623,6 @@ double cFeature::getDistance(string strName, double mean, double std,
 }
 
 string cFeature::featuretype(string featurename) {
-  int npos = featurename.find(";");
-  if (npos != string::npos) {
-    featurename = featurename.substr(0, npos);
-  }
   if (featurename == "__test_efel_assertion__")  // for testing only
     throw EfelAssertionError("Test efel assertion is successfully triggered.");
   string type = featuretypes[featurename];

--- a/efel/cppcore/cfeature.cpp
+++ b/efel/cppcore/cfeature.cpp
@@ -623,6 +623,10 @@ double cFeature::getDistance(string strName, double mean, double std,
 }
 
 string cFeature::featuretype(string featurename) {
+  int npos = featurename.find(";");
+  if (npos != string::npos) {
+    featurename = featurename.substr(0, npos);
+  }
   if (featurename == "__test_efel_assertion__")  // for testing only
     throw EfelAssertionError("Test efel assertion is successfully triggered.");
   string type = featuretypes[featurename];

--- a/efel/cppcore/cfeature.cpp
+++ b/efel/cppcore/cfeature.cpp
@@ -374,12 +374,7 @@ int cFeature::calc_features(const string& name) {
   map<string, vector<featureStringPair> >::const_iterator lookup_it(
       fptrlookup.find(name));
   if (lookup_it == fptrlookup.end()) {
-    fprintf(stderr,
-            "\nFeature [ %s ] dependency file entry or pointer table entry is "
-            "missing. Exiting\n",
-            name.c_str());
-    fflush(stderr);
-    exit(1);
+      throw std::runtime_error("Feature dependency file entry or pointer table entry is missing.");
   }
 
   bool last_failed = false;
@@ -581,17 +576,12 @@ double cFeature::getDistance(string strName, double mean, double std,
       }
   }
 
-  // check datatype of feature
   featureType = featuretype(strName);
-  if (featureType.empty()) {
-    printf("Error : Feature [%s] not found. Exiting..\n", strName.c_str());
-    exit(1);
-  }
 
   if (featureType == "int") {
     retVal = getFeature<int>(strName, feature_veci);
     intFlag = 1;
-  } else {
+  } else { // double
     retVal = getFeature<double>(strName, feature_vec);
     intFlag = 0;
   }
@@ -634,12 +624,12 @@ double cFeature::getDistance(string strName, double mean, double std,
 
 string cFeature::featuretype(string featurename) {
   int npos = featurename.find(";");
-  if (npos >= 0) {
+  if (npos != string::npos) {
     featurename = featurename.substr(0, npos);
   }
-  string type(featuretypes[featurename]);
-  if (type.empty()) {
-    GErrorStr += featurename + "missing in featuretypes map.\n";
+  string type = featuretypes[featurename];
+  if (type != "int" && type != "double") {
+    throw std::runtime_error("Unknown feature name: " + featurename);
   }
   return type;
 }

--- a/efel/cppcore/cppcore.cpp
+++ b/efel/cppcore/cppcore.cpp
@@ -117,27 +117,39 @@ _getfeature(PyObject* self, PyObject* args, const string &type) {
     return NULL;
   }
 
-  string feature_type = pFeature->featuretype(string(feature_name));
+  string feature_type;
+  try
+  {
+    feature_type = pFeature->featuretype(string(feature_name));
+  }
+  catch(const std::runtime_error& e)
+  {
+    PyErr_SetString(PyExc_RuntimeError, e.what());
+    return NULL;
+  }
 
-  if (!type.empty() && feature_type != type){
+  if (!type.empty() && feature_type != type){  // when types do not match
     PyErr_SetString(PyExc_TypeError, "Feature type does not match");
     return NULL;
   }
 
-  if (feature_type == "int") {
-    vector<int> values;
-    return_value = pFeature->getFeature<int>(string(feature_name), values);
-    PyList_from_vectorint(values, py_values);
-  } else if (feature_type == "double") {
-    vector<double> values;
-    return_value = pFeature->getFeature<double>(string(feature_name), values);
-    PyList_from_vectordouble(values, py_values);
-  } else {
-    PyErr_SetString(PyExc_TypeError, "Unknown feature name");
+  try {
+    if (feature_type == "int") {
+      vector<int> values;
+      return_value = pFeature->getFeature<int>(string(feature_name), values);
+      PyList_from_vectorint(values, py_values);
+      return Py_BuildValue("i", return_value);
+    } else { // double
+      vector<double> values;
+      return_value = pFeature->getFeature<double>(string(feature_name), values);
+      PyList_from_vectordouble(values, py_values);
+      return Py_BuildValue("i", return_value);
+    }
+  }
+  catch(const std::runtime_error& e) {
+    PyErr_SetString(PyExc_RuntimeError, e.what());
     return NULL;
   }
-
-  return Py_BuildValue("i", return_value);
 }
 
 

--- a/efel/cppcore/cppcore.cpp
+++ b/efel/cppcore/cppcore.cpp
@@ -118,8 +118,7 @@ _getfeature(PyObject* self, PyObject* args, const string &input_type) {
   }
 
   string feature_type;
-  try
-  {
+  try {
     feature_type = pFeature->featuretype(string(feature_name));
   }
   catch(const std::runtime_error& e)
@@ -146,8 +145,16 @@ _getfeature(PyObject* self, PyObject* args, const string &input_type) {
       return Py_BuildValue("i", return_value);
     }
   }
+  catch(EfelAssertionError& e) {  // more specialised exception
+    PyErr_SetString(PyExc_AssertionError, e.what());
+    return NULL;
+  }
   catch(const std::runtime_error& e) {
     PyErr_SetString(PyExc_RuntimeError, e.what());
+    return NULL;
+  }
+  catch(...) {
+    PyErr_SetString(PyExc_RuntimeError, "Unknown error");
     return NULL;
   }
 }

--- a/efel/cppcore/cppcore.cpp
+++ b/efel/cppcore/cppcore.cpp
@@ -114,25 +114,18 @@ _getfeature(PyObject* self, PyObject* args, const string &input_type) {
 
   int return_value;
   if (!PyArg_ParseTuple(args, "sO!", &feature_name, &PyList_Type, &py_values)) {
-    return NULL;
-  }
-
-  string feature_type;
-  try {
-    feature_type = pFeature->featuretype(string(feature_name));
-  }
-  catch(const std::runtime_error& e)
-  {
-    PyErr_SetString(PyExc_RuntimeError, e.what());
-    return NULL;
-  }
-
-  if (!input_type.empty() && feature_type != input_type){  // when types do not match
-    PyErr_SetString(PyExc_TypeError, "Feature type does not match");
+    PyErr_SetString(PyExc_TypeError, "Unexpected argument type provided.");
     return NULL;
   }
 
   try {
+    string feature_type = pFeature->featuretype(string(feature_name));
+
+    if (!input_type.empty() && feature_type != input_type){  // when types do not match
+      PyErr_SetString(PyExc_TypeError, "Feature type does not match");
+      return NULL;
+    }
+
     if (feature_type == "int") {
       vector<int> values;
       return_value = pFeature->getFeature<int>(string(feature_name), values);

--- a/efel/cppcore/cppcore.cpp
+++ b/efel/cppcore/cppcore.cpp
@@ -108,7 +108,7 @@ static void PyList_from_vectorstring(vector<string> input, PyObject* output) {
 }
 
 static PyObject*
-_getfeature(PyObject* self, PyObject* args, const string &type) {
+_getfeature(PyObject* self, PyObject* args, const string &input_type) {
   char* feature_name;
   PyObject* py_values;
 
@@ -128,7 +128,7 @@ _getfeature(PyObject* self, PyObject* args, const string &type) {
     return NULL;
   }
 
-  if (!type.empty() && feature_type != type){  // when types do not match
+  if (!input_type.empty() && feature_type != input_type){  // when types do not match
     PyErr_SetString(PyExc_TypeError, "Feature type does not match");
     return NULL;
   }

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -183,7 +183,7 @@ def test_nonexisting_feature():
     trace['stim_end'] = [75]
 
     pytest.raises(
-        TypeError,
+        RuntimeError,
         efel.getFeatureValues,
         [trace],
         ['nonexisting_feature'])

--- a/tests/test_cppcore.py
+++ b/tests/test_cppcore.py
@@ -212,7 +212,7 @@ class TestCppcore:
 
 
 def test_efel_assertion_error():
-    """Testing if c++ assertion error is propagated to python acorrectly."""
+    """Testing if C++ assertion error is propagated to Python correctly."""
     import efel
     efel.reset()
     trace = {

--- a/tests/test_cppcore.py
+++ b/tests/test_cppcore.py
@@ -160,7 +160,7 @@ class TestCppcore:
         return_value = efel.cppcore.getFeature("AP_amplitude", feature_values)
         assert return_value == -1
 
-    @pytest.mark.xfail(raises=TypeError)
+    @pytest.mark.xfail(raises=RuntimeError)
     def test_getFeature_non_existant(self):  # pylint: disable=R0201
         """cppcore: Testing failure exit code in getFeature"""
         import efel

--- a/tests/test_cppcore.py
+++ b/tests/test_cppcore.py
@@ -209,3 +209,15 @@ class TestCppcore:
         assert contents.count(f"Calculated feature {feature_name}") == 1
         # make sure Reusing computed value of text occurs twice
         assert contents.count(f"Reusing computed value of {feature_name}") == 2
+
+
+def test_efel_assertion_error():
+    """Testing if c++ assertion error is propagated to python acorrectly."""
+    import efel
+    efel.reset()
+    trace = {
+        "stim_start": [25],
+        "stim_end": [75],
+    }
+    with pytest.raises(AssertionError):
+        efel.getFeatureValues([trace], ["__test_efel_assertion__"])


### PR DESCRIPTION
When `exit(1)`  is called within a C++ library that's being used by Python (e.g., through a Python API), it will terminate the entire process. 

This PR replaces the `exit(1)` statements with exception handling. It further translates C++ exceptions to Python's built-in exceptions to enable graceful failures.

Given the frequent use of exit calls throughout eFEL – appearing in over 15 distinct locations, notably within the frequently used LinearInterpolation function – this update is expected to prevent approximately 95% of potential future crashes.


Related to #321 .