### PR TITLE
add EfelExceptions.h to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ cppcore_headers = ['Utils.h',
                    'Global.h',
                    'mapoperations.h',
                    'types.h',
-                   'eFELLogger.h']
+                   'eFELLogger.h',
+                   'EfelExceptions.h']
 cppcore_sources = [
     os.path.join(
         cppcore_dir,


### PR DESCRIPTION
EfelExceptions.h file was added in PR #329 but it was not added to the headers list in setup. Because of this, it was not included in the tarball, and users would not be able to install efel without wheels.

Fixes Issue #332 