### PR TITLE
New function `to_json_ld` to output features to json-ld

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+5.5.6 - 2024-01
+----------------
+
+- New function `to_json_ld` to output the feature results with ids and units in JSON-LD format.
+
 5.5.5 - 2024-01
 ----------------
 - Type annotate api.py's functions.

--- a/efel/io.py
+++ b/efel/io.py
@@ -214,7 +214,7 @@ def load_neo_file(file_name: str, stim_start=None, stim_end=None, **kwargs) -> l
 
 def to_json_ld(feature_values: list[dict[str, np.ndarray]]) -> str:
     """Converts the extracted features to the JSON-LD format."""
-    context = "https://neuroshapes.org/"
+    context = "https://bbp.neuroshapes.org"
     ontology_ns = "https://bbp.epfl.ch/ontologies/core/efeatures/"
     units_ns = "https://neuroshapes.org/units"
     json_ld: dict[str, Any] = {"@context": context, "data": []}

--- a/efel/io.py
+++ b/efel/io.py
@@ -1,4 +1,8 @@
 from __future__ import annotations
+import json
+from typing import Any
+
+from efel.units import get_unit
 """IO handler for eFEL"""
 
 """
@@ -206,3 +210,25 @@ def load_neo_file(file_name: str, stim_start=None, stim_end=None, **kwargs) -> l
         efel_blocks.append(efel_segments)
 
     return efel_blocks
+
+
+def to_json_ld(feature_values: list[dict[str, np.ndarray]]) -> str:
+    """Converts the extracted features to the JSON-LD format."""
+    context = "https://neuroshapes.org/"
+    ontology_ns = "https://bbp.epfl.ch/ontologies/core/efeatures/"
+    units_ns = "https://neuroshapes.org/units"
+    json_ld: dict[str, Any] = {"@context": context, "data": []}
+
+    for feature_dict in feature_values:
+        data_entry = {}
+        for feature_name, values in feature_dict.items():
+            # @id and units for each feature
+            json_ld[feature_name] = {
+                "@id": f"{ontology_ns}{feature_name}",
+                "unit": f"{units_ns}/{get_unit(feature_name)}"
+            }
+            # Add feature values to data entry
+            data_entry[feature_name] = values.tolist()
+        json_ld["data"].append(data_entry)
+
+    return json.dumps(json_ld, indent=2)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -286,7 +286,7 @@ def test_to_json_ld():
     ]
     # test_data values are for for testing purposes they are not scientifically accurate
     expected_output = {
-        "@context": "https://neuroshapes.org/",
+        "@context": "https://bbp.neuroshapes.org",
         "data": [
             {
                 "AHP_depth": [

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,12 +1,13 @@
 """Test eFEL io module"""
 
+import json
 import os
 from pathlib import Path
 import numpy as np
 
 import pytest
 
-from efel.io import load_ascii_input
+from efel.io import load_ascii_input, to_json_ld
 
 
 testdata_dir = Path(__file__).parent / 'testdata'
@@ -269,3 +270,54 @@ def test_load_neo_file_stim_time_events_incomplete():
                              "neo_test_file_events_time_incomplete.mat")
 
     pytest.raises(ValueError, efel.io.load_neo_file, file_name)
+
+
+def test_to_json_ld():
+    """Tests the conversion of extracted feature values to JSON-LD."""
+    test_data = [
+        {
+            "AHP_depth": np.array([26.998080940503804, 27.3636342342]),
+            "AP_amplitude": np.array([72.0, 72.0]),
+        },
+        {
+            "AHP_depth": np.array([56.3645747546, 55.142543543]),
+            "AP_amplitude": np.array([74.2, 73.2]),
+        },
+    ]
+    # test_data values are for for testing purposes they are not scientifically accurate
+    expected_output = {
+        "@context": "https://neuroshapes.org/",
+        "data": [
+            {
+                "AHP_depth": [
+                    26.998080940503804,
+                    27.3636342342
+                ],
+                "AP_amplitude": [
+                    72.0,
+                    72.0
+                ]
+            },
+            {
+                "AHP_depth": [
+                    56.3645747546,
+                    55.142543543
+                ],
+                "AP_amplitude": [
+                    74.2,
+                    73.2
+                ]
+            }
+        ],
+        "AHP_depth": {
+            "@id": "https://bbp.epfl.ch/ontologies/core/efeatures/AHP_depth",
+            "unit": "https://neuroshapes.org/units/mV"
+        },
+        "AP_amplitude": {
+            "@id": "https://bbp.epfl.ch/ontologies/core/efeatures/AP_amplitude",
+            "unit": "https://neuroshapes.org/units/mV"
+        }
+    }
+
+    result = to_json_ld(test_data)
+    assert result == json.dumps(expected_output, indent=2)


### PR DESCRIPTION
## Description

Adds a new function to output efel's features to JSON-LD format with annotations for the feature ids and the units. 

Below is the classical output of eFEL extracted on 2 traces using 2 features.

```
[
        {
            "AHP_depth": np.array([26.998080940503804, 27.3636342342]),
            "AP_amplitude": np.array([72.0, 72.0]),
        },
        {
            "AHP_depth": np.array([56.3645747546, 55.142543543]),
            "AP_amplitude": np.array([74.2, 73.2]),
        },
]
```

It's corresponding json-ld output is the following.
```
{
  "@context": "https://bbp.neuroshapes.org",
  "data": [
    {
      "AHP_depth": [
        26.998080940503804,
        27.3636342342
      ],
      "AP_amplitude": [
        72.0,
        72.0
      ]
    },
    {
      "AHP_depth": [
        56.3645747546,
        55.142543543
      ],
      "AP_amplitude": [
        74.2,
        73.2
      ]
    }
  ],
  "AHP_depth": {
    "@id": "https://bbp.epfl.ch/ontologies/core/efeatures/AHP_depth",
    "unit": "https://neuroshapes.org/units/mV"
  },
  "AP_amplitude": {
    "@id": "https://bbp.epfl.ch/ontologies/core/efeatures/AP_amplitude",
    "unit": "https://neuroshapes.org/units/mV"
  }
}

```



## Checklist:
- [X] Unit tests are added to cover the changes (skip if not applicable).
- [X] The changes are mentioned in the documentation (skip if not applicable).
- [X] CHANGELOG file is updated (skip if not applicable).
