### PR TITLE
rm cp38 from wheel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-latest, windows-latest]
-        python: [cp38, cp39, cp310, cp311, cp312]
+        python: [cp39, cp310, cp311, cp312]
         arch: [x86_64, amd64]
         exclude:
           - os: macos-latest


### PR DESCRIPTION
## Description

Removes cp38 from the wheel build since the recent scipy does not support it (and the old scipy does not support cp312).


## Checklist:
- [ ] Unit tests are added to cover the changes (skip if not applicable).
- [ ] The changes are mentioned in the documentation (skip if not applicable).
- [ ] CHANGELOG file is updated (skip if not applicable).
