### PR TITLE
adding AP_height to documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+5.6.6 - 2024-04
+---------------
+
+- Adding AP_height to documentation
+
 5.6.0 - 2024-02
 ----------------
 

--- a/docs/source/eFeatures.rst
+++ b/docs/source/eFeatures.rst
@@ -618,6 +618,16 @@ The voltages at the maxima of the peaks
 
     peak_voltage = voltage[peak_indices]
 
+`LibV1`_ : AP_height
+~~~~~~~~~~~~~~~~~~~~
+
+Same as peak_voltage: The voltages at the maxima of the peaks
+
+- **Required features**: LibV1:peak_voltage
+- **Units**: mV
+- **Pseudocode**: ::
+
+    AP_height = peak_voltage
 
 `LibV1`_ : AP_amplitude, AP1_amp, AP2_amp, APlast_amp
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/sonata-network/sonata-network.ipynb
+++ b/examples/sonata-network/sonata-network.ipynb
@@ -43,7 +43,7 @@
     "\n",
     "from matplotlib import pyplot as plt\n",
     "\n",
-    "from bluecellulab import SSim\n",
+    "from bluecellulab import CircuitSimulation\n",
     "import efel"
    ]
   },
@@ -136,7 +136,7 @@
     "simulation_config = Path(\"./\") / \"simulation_config.json\"\n",
     "with open(simulation_config) as f:\n",
     "    simulation_config_dict = json.load(f)\n",
-    "sim = SSim(simulation_config)"
+    "sim = CircuitSimulation(simulation_config)"
    ]
   },
   {
@@ -368,6 +368,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Description

adding AP_height to documentation


## Checklist:
- [ skip] Unit tests are added to cover the changes (skip if not applicable).
- [ skip] The changes are mentioned in the documentation (skip if not applicable).
- [ X ] CHANGELOG file is updated (skip if not applicable).
