### PR TITLE
set settings logger with debug instead of warning

### DIFF
--- a/efel/settings.py
+++ b/efel/settings.py
@@ -120,7 +120,7 @@ class Settings:
                 raise ValueError(f"Invalid value for setting '{setting_name}'. "
                                  f"Expected type: {expected_type.__name__}.")
         else:
-            logger.warning("Setting '%s' not found in settings. "
+            logger.debug("Setting '%s' not found in settings. "
                            "Adding it as a new setting.", setting_name)
 
         if setting_name == "dependencyfile_path":


### PR DESCRIPTION
## Description

Motivation: Overall I don't this this should be a warning, a simple debug statement is enough. There are a lot of stuff that are not defined in settings, but can be set as such (stim_start, stim_end, stimulus_current, etc.), this is something expected. 

BluePyEModel sets stimulus_current, sometimes even stim_start, stim_end, and I see this warning a lot


## Checklist:
- [ ] Unit tests are added to cover the changes (skip if not applicable).
- [ ] The changes are mentioned in the documentation (skip if not applicable).
- [ ] CHANGELOG file is updated (skip if not applicable).
