### PR TITLE
fix impedance freq indexing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+5.6.7 - 2024-08
+---------------
+
+- Fixed impedance feature (frequency index was inconsistent with smooth Z)
+
 5.7.1 - 2024-07
 ---------------
 

--- a/efel/pyfeatures/pyfeatures.py
+++ b/efel/pyfeatures/pyfeatures.py
@@ -171,7 +171,7 @@ def impedance():
             )[0]
             smooth_Z = gaussian_filter1d(norm_Z[select_idxs], 10)
             ind_max = np.argmax(smooth_Z)
-            return np.array([freq[ind_max]])
+            return np.array([freq[select_idxs][ind_max]])
         else:
             return None
     else:

--- a/tests/test_pyfeatures.py
+++ b/tests/test_pyfeatures.py
@@ -307,7 +307,7 @@ def test_impedance():
     """pyfeatures: Test impedance feature"""
     feature_name = "impedance"
 
-    expected_values = {feature_name: 4.615384615384615}
+    expected_values = {feature_name: 4.80769231}
     _test_expected_value(feature_name, expected_values)
 
 


### PR DESCRIPTION
## Description

We change the indexing of smooth_Z, but forget to also change the indexing of freq when applying a smooth_Z index. This should solve the impedance = 0.0 results that we were getting.


## Checklist:
- [ ] Unit tests are added to cover the changes (skip if not applicable).
- [ ] The changes are mentioned in the documentation (skip if not applicable).
- [x] CHANGELOG file is updated (skip if not applicable).
