### PR TITLE
updating ebrains access token secret in workflow

### DIFF
--- a/.github/workflows/mirror-ebrains.yml
+++ b/.github/workflows/mirror-ebrains.yml
@@ -13,12 +13,12 @@ jobs:
         with:
           source_repo: "BlueBrain/eFEL"
           source_branch: "master"
-          destination_repo: "https://ghpusher:${{ secrets.EBRAINS_GITLAB_ACCESS_TOKEN }}@gitlab.ebrains.eu/BlueBrain/efel.git"
+          destination_repo: "https://ghpusher:${{ secrets.EBRAINS_GITLAB_ACCESS_TOKEN_2024 }}@gitlab.ebrains.eu/BlueBrain/efel.git"
           destination_branch: "master"
       - name: synctags
         uses: wei/git-sync@v3
         with:
           source_repo: "BlueBrain/eFEL"
           source_branch: "refs/tags/*"
-          destination_repo: "https://ghpusher:${{ secrets.EBRAINS_GITLAB_ACCESS_TOKEN }}@gitlab.ebrains.eu/BlueBrain/efel.git"
+          destination_repo: "https://ghpusher:${{ secrets.EBRAINS_GITLAB_ACCESS_TOKEN_2024 }}@gitlab.ebrains.eu/BlueBrain/efel.git"
           destination_branch: "refs/tags/*"


### PR DESCRIPTION
## Description

Updating to use latest access token. We suspect the previous one has expired on ebrains gitlab side.


## Checklist:
- [ ] Unit tests are added to cover the changes (skip if not applicable).
- [ ] The changes are mentioned in the documentation (skip if not applicable).
- [ ] CHANGELOG file is updated (skip if not applicable).
